### PR TITLE
Reject trailing bytes

### DIFF
--- a/src/config/legacy.rs
+++ b/src/config/legacy.rs
@@ -49,6 +49,7 @@ macro_rules! config_map {
             (Unlimited, Little) => {
                 let $opts = DefaultOptions::new()
                     .with_fixint_encoding()
+                    .allow_trailing_bytes()
                     .with_no_limit()
                     .with_little_endian();
                 $call
@@ -56,6 +57,7 @@ macro_rules! config_map {
             (Unlimited, Big) => {
                 let $opts = DefaultOptions::new()
                     .with_fixint_encoding()
+                    .allow_trailing_bytes()
                     .with_no_limit()
                     .with_big_endian();
                 $call
@@ -63,6 +65,7 @@ macro_rules! config_map {
             (Unlimited, Native) => {
                 let $opts = DefaultOptions::new()
                     .with_fixint_encoding()
+                    .allow_trailing_bytes()
                     .with_no_limit()
                     .with_native_endian();
                 $call
@@ -71,6 +74,7 @@ macro_rules! config_map {
             (Limited(l), Little) => {
                 let $opts = DefaultOptions::new()
                     .with_fixint_encoding()
+                    .allow_trailing_bytes()
                     .with_limit(l)
                     .with_little_endian();
                 $call
@@ -78,6 +82,7 @@ macro_rules! config_map {
             (Limited(l), Big) => {
                 let $opts = DefaultOptions::new()
                     .with_fixint_encoding()
+                    .allow_trailing_bytes()
                     .with_limit(l)
                     .with_big_endian();
                 $call
@@ -85,6 +90,7 @@ macro_rules! config_map {
             (Limited(l), Native) => {
                 let $opts = DefaultOptions::new()
                     .with_fixint_encoding()
+                    .allow_trailing_bytes()
                     .with_limit(l)
                     .with_native_endian();
                 $call

--- a/src/config/trailing.rs
+++ b/src/config/trailing.rs
@@ -1,5 +1,5 @@
-use ::de::read::SliceReader;
-use {Result, ErrorKind};
+use de::read::SliceReader;
+use {ErrorKind, Result};
 
 /// A trait for erroring deserialization if not all bytes were read.
 pub trait TrailingBytes {
@@ -29,7 +29,9 @@ impl TrailingBytes for RejectTrailing {
         if reader.is_finished() {
             Ok(())
         } else {
-            Err(Box::new(ErrorKind::Custom("Slice had bytes remaining after deserialization".to_string())))
+            Err(Box::new(ErrorKind::Custom(
+                "Slice had bytes remaining after deserialization".to_string(),
+            )))
         }
     }
 }

--- a/src/config/trailing.rs
+++ b/src/config/trailing.rs
@@ -1,0 +1,35 @@
+use ::de::read::SliceReader;
+use {Result, ErrorKind};
+
+/// A trait for erroring deserialization if not all bytes were read.
+pub trait TrailingBytes {
+    /// Checks a given slice reader to determine if deserialization used all bytes in the slice.
+    fn check_end(reader: &SliceReader) -> Result<()>;
+}
+
+/// A TrailingBytes config that will allow trailing bytes in slices after deserialization.
+#[derive(Copy, Clone)]
+pub struct AllowTrailing;
+
+/// A TrailingBytes config that will cause bincode to produce an error if bytes are left over in the slice when deserialization is complete.
+
+#[derive(Copy, Clone)]
+pub struct RejectTrailing;
+
+impl TrailingBytes for AllowTrailing {
+    #[inline(always)]
+    fn check_end(_reader: &SliceReader) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl TrailingBytes for RejectTrailing {
+    #[inline(always)]
+    fn check_end(reader: &SliceReader) -> Result<()> {
+        if reader.is_finished() {
+            Ok(())
+        } else {
+            Err(Box::new(ErrorKind::Custom("Slice had bytes remaining after deserialization".to_string())))
+        }
+    }
+}

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -26,7 +26,7 @@ pub mod read;
 /// let bytes_read = d.bytes_read();
 /// ```
 pub struct Deserializer<R, O: Options> {
-    reader: R,
+    pub(crate) reader: R,
     options: O,
 }
 

--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -68,7 +68,7 @@ impl<R> IoReader<R> {
     }
 }
 
-impl<'a, 'storage> io::Read for &'a mut SliceReader<'storage> {
+impl<'storage> io::Read for SliceReader<'storage> {
     #[inline(always)]
     fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
         if out.len() > self.slice.len() {
@@ -108,7 +108,7 @@ impl<'storage> SliceReader<'storage> {
     }
 }
 
-impl<'a, 'storage> BincodeRead<'storage> for &'a mut SliceReader<'storage> {
+impl<'storage> BincodeRead<'storage> for SliceReader<'storage> {
     #[inline(always)]
     fn forward_read_str<V>(&mut self, length: usize, visitor: V) -> Result<V::Value>
     where

--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -52,6 +52,10 @@ impl<'storage> SliceReader<'storage> {
         self.slice = remaining;
         Ok(read_slice)
     }
+
+    pub(crate) fn is_finished(&self) -> bool {
+        self.slice.is_empty()
+    }
 }
 
 impl<R> IoReader<R> {
@@ -64,7 +68,7 @@ impl<R> IoReader<R> {
     }
 }
 
-impl<'storage> io::Read for SliceReader<'storage> {
+impl<'a, 'storage> io::Read for &'a mut SliceReader<'storage> {
     #[inline(always)]
     fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
         if out.len() > self.slice.len() {
@@ -104,7 +108,7 @@ impl<'storage> SliceReader<'storage> {
     }
 }
 
-impl<'storage> BincodeRead<'storage> for SliceReader<'storage> {
+impl<'a, 'storage> BincodeRead<'storage> for &'a mut SliceReader<'storage> {
     #[inline(always)]
     fn forward_read_str<V>(&mut self, length: usize, visitor: V) -> Result<V::Value>
     where

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,8 @@ pub enum ErrorKind {
     SizeLimit,
     /// Bincode can not encode sequences of unknown length (like iterators).
     SequenceMustHaveLength,
+    /// Bincode will not decode from slices that have trailing bytes
+    TrailingBytes,
     /// A custom error message from Serde.
     Custom(String),
 }
@@ -54,6 +56,7 @@ impl StdError for ErrorKind {
                 "Bincode doesn't support serde::Deserializer::deserialize_any"
             }
             ErrorKind::SizeLimit => "the size limit has been reached",
+            ErrorKind::TrailingBytes => "input slice has extra bytes after decoding",
             ErrorKind::Custom(ref msg) => msg,
         }
     }
@@ -68,6 +71,7 @@ impl StdError for ErrorKind {
             ErrorKind::SequenceMustHaveLength => None,
             ErrorKind::DeserializeAnyNotSupported => None,
             ErrorKind::SizeLimit => None,
+            ErrorKind::TrailingBytes => None,
             ErrorKind::Custom(_) => None,
         }
     }
@@ -93,6 +97,7 @@ impl fmt::Display for ErrorKind {
             }
             ErrorKind::SequenceMustHaveLength => write!(fmt, "{}", self.description()),
             ErrorKind::SizeLimit => write!(fmt, "{}", self.description()),
+            ErrorKind::TrailingBytes => write!(fmt, "{}", self.description()),
             ErrorKind::DeserializeAnyNotSupported => write!(
                 fmt,
                 "Bincode does not support the serde::Deserializer::deserialize_any method"

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,8 +35,6 @@ pub enum ErrorKind {
     SizeLimit,
     /// Bincode can not encode sequences of unknown length (like iterators).
     SequenceMustHaveLength,
-    /// Bincode will not decode from slices that have trailing bytes
-    TrailingBytes,
     /// A custom error message from Serde.
     Custom(String),
 }
@@ -56,7 +54,6 @@ impl StdError for ErrorKind {
                 "Bincode doesn't support serde::Deserializer::deserialize_any"
             }
             ErrorKind::SizeLimit => "the size limit has been reached",
-            ErrorKind::TrailingBytes => "input slice has extra bytes after decoding",
             ErrorKind::Custom(ref msg) => msg,
         }
     }
@@ -71,7 +68,6 @@ impl StdError for ErrorKind {
             ErrorKind::SequenceMustHaveLength => None,
             ErrorKind::DeserializeAnyNotSupported => None,
             ErrorKind::SizeLimit => None,
-            ErrorKind::TrailingBytes => None,
             ErrorKind::Custom(_) => None,
         }
     }
@@ -97,7 +93,6 @@ impl fmt::Display for ErrorKind {
             }
             ErrorKind::SequenceMustHaveLength => write!(fmt, "{}", self.description()),
             ErrorKind::SizeLimit => write!(fmt, "{}", self.description()),
-            ErrorKind::TrailingBytes => write!(fmt, "{}", self.description()),
             ErrorKind::DeserializeAnyNotSupported => write!(
                 fmt,
                 "Bincode does not support the serde::Deserializer::deserialize_any method"

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -111,7 +111,17 @@ where
     T: serde::de::DeserializeSeed<'a>,
     O: InternalOptions,
 {
-    let reader = ::de::read::SliceReader::new(bytes);
+    let mut reader = ::de::read::SliceReader::new(bytes);
     let options = ::config::WithOtherLimit::new(options, Infinite);
-    deserialize_from_custom_seed(seed, reader, options)
+
+    match deserialize_from_custom_seed(seed, &mut reader, options) {
+        Ok(val) => {
+            if reader.is_finished() {
+                Ok(val)
+            } else {
+                Err(Box::new(ErrorKind::TrailingBytes))
+            }
+        },
+        err => err
+    }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -116,9 +116,9 @@ where
     let reader = ::de::read::SliceReader::new(bytes);
     let mut deserializer = ::de::Deserializer::with_bincode_read(reader, options);
     let val = seed.deserialize(&mut deserializer)?;
-    
+
     match O::Trailing::check_end(&deserializer.reader) {
         Ok(_) => Ok(val),
-        Err(err) => Err(err)
+        Err(err) => Err(err),
     }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -2,7 +2,7 @@ use serde;
 use std::io::{Read, Write};
 use std::marker::PhantomData;
 
-use config::{Infinite, InternalOptions, Options, SizeLimit};
+use config::{Infinite, InternalOptions, Options, SizeLimit, TrailingBytes};
 use de::read::BincodeRead;
 use Result;
 
@@ -111,17 +111,14 @@ where
     T: serde::de::DeserializeSeed<'a>,
     O: InternalOptions,
 {
-    let mut reader = ::de::read::SliceReader::new(bytes);
     let options = ::config::WithOtherLimit::new(options, Infinite);
 
-    match deserialize_from_custom_seed(seed, &mut reader, options) {
-        Ok(val) => {
-            if reader.is_finished() {
-                Ok(val)
-            } else {
-                Err(Box::new(ErrorKind::TrailingBytes))
-            }
-        },
-        err => err
+    let reader = ::de::read::SliceReader::new(bytes);
+    let mut deserializer = ::de::Deserializer::with_bincode_read(reader, options);
+    let val = seed.deserialize(&mut deserializer)?;
+    
+    match O::Trailing::check_end(&deserializer.reader) {
+        Ok(_) => Ok(val),
+        Err(err) => Err(err)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ where
 {
     DefaultOptions::new()
         .with_fixint_encoding()
+        .allow_trailing_bytes()
         .serialize(value)
 }
 
@@ -107,6 +108,7 @@ where
 {
     DefaultOptions::new()
         .with_fixint_encoding()
+        .allow_trailing_bytes()
         .deserialize_from(reader)
 }
 
@@ -122,6 +124,7 @@ where
 {
     DefaultOptions::new()
         .with_fixint_encoding()
+        .allow_trailing_bytes()
         .deserialize_from_custom(reader)
 }
 
@@ -136,6 +139,7 @@ where
 {
     DefaultOptions::new()
         .with_fixint_encoding()
+        .allow_trailing_bytes()
         .deserialize_in_place(reader, place)
 }
 
@@ -146,6 +150,7 @@ where
 {
     DefaultOptions::new()
         .with_fixint_encoding()
+        .allow_trailing_bytes()
         .deserialize(bytes)
 }
 
@@ -156,5 +161,6 @@ where
 {
     DefaultOptions::new()
         .with_fixint_encoding()
+        .allow_trailing_bytes()
         .serialized_size(value)
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -279,9 +279,12 @@ fn deserializing_errors() {
 
 #[test]
 fn trailing_bytes() {
-    match DefaultOptions::new().deserialize::<char>(b"1x").map_err(|e| *e) {
-        Err(ErrorKind::Custom(_)) => {},
-        other => panic!("Expecting TrailingBytes, got {:?}", other)
+    match DefaultOptions::new()
+        .deserialize::<char>(b"1x")
+        .map_err(|e| *e)
+    {
+        Err(ErrorKind::Custom(_)) => {}
+        other => panic!("Expecting TrailingBytes, got {:?}", other),
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -278,6 +278,14 @@ fn deserializing_errors() {
 }
 
 #[test]
+fn trailing_bytes() {
+    match deserialize::<char>(b"1x").map_err(|e| *e) {
+        Err(ErrorKind::TrailingBytes) => {},
+        other => panic!("Expecting TrailingBytes, got {:?}", other)
+    }
+}
+
+#[test]
 fn too_big_deserialize() {
     let serialized = vec![0, 0, 0, 3];
     let deserialized: Result<u32> = DefaultOptions::new()

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -279,8 +279,8 @@ fn deserializing_errors() {
 
 #[test]
 fn trailing_bytes() {
-    match deserialize::<char>(b"1x").map_err(|e| *e) {
-        Err(ErrorKind::TrailingBytes) => {},
+    match DefaultOptions::new().deserialize::<char>(b"1x").map_err(|e| *e) {
+        Err(ErrorKind::Custom(_)) => {},
         other => panic!("Expecting TrailingBytes, got {:?}", other)
     }
 }


### PR DESCRIPTION
Closes #193 

There were two design possibilities I considered for tackling this problem. The current one changes the impls on `SliceReader` to be impls for `&mut SliceReader`. This allows me to access it after passing it to the deserializer. The other option would be to allow `pub(restricted)` access to the reader field of the deserializer and access it from there. 