### PR TITLE
Varint enum tags and lengths behind a feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ rust:
     - beta
     - nightly
 
-script: cargo test
+script:
+  - cargo test
+  - cargo test --features "varint"
 
 matrix:
   include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,9 @@ autocfg = "0.1.2"
 # feature will be removed if and when a new major version is released.
 i128 = []
 
+# Enabling this feature will make bincode treat enum discriminants and
+# sequence lengths as varints instead of u32s.
+varint = []
+
 [badges]
 travis-ci = { repository = "servo/bincode" }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -82,16 +82,17 @@ impl<'de, R: BincodeRead<'de>, O: Options> Deserializer<R, O> {
     }
 
     fn deserialize_varint(&mut self) -> Result<usize> {
-        let mut byte: u8 = try!(serde::Deserialize::deserialize(&mut *self));
         let mut n = 0;
+        let mut shift = 0;
+        let mut byte: u8 = try!(serde::Deserialize::deserialize(&mut *self));
 
         while byte > 127 {
-            n |= (byte & 127) as usize;
+            n |= ((byte & 127) as usize) << shift;
+            shift += 7;
             byte = try!(serde::Deserialize::deserialize(&mut *self));
-            n <<= 7;
         }
 
-        Ok(n | byte as usize)
+        Ok(n | ((byte as usize) << shift))
     }
 }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -314,11 +314,15 @@ impl<O: Options> SizeChecker<O> {
         self.add_varint(len)
     }
 
-    fn add_varint(&mut self, int: usize) -> Result<()> {
-        use std::mem::size_of;
-        let bits = size_of::<usize>() * 8 - int.leading_zeros() as usize;
+    fn add_varint(&mut self, mut n: usize) -> Result<()> {
+        let mut bytes = 1;
 
-        self.add_raw(((bits.saturating_sub(1) / 7) + 1) as u64)
+        while n > 127 {
+            n >>= 7;
+            bytes += 1;
+        }
+
+        self.add_raw(bytes)
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -699,8 +699,18 @@ fn test_big_endian_deserialize_seed() {
 #[cfg(feature = "varint")]
 #[test]
 fn test_varint_length_prefixes() {
-    assert_eq!(serialized_size(&vec![0u8; 127][..]).unwrap(), 1 + 127); // 2 ** 7 - 1
-    assert_eq!(serialized_size(&vec![0u8; 128][..]).unwrap(), 2 + 128); // 2 ** 7
-    assert_eq!(serialized_size(&vec![0u8; 16383][..]).unwrap(), 2 + 16383); // 2 ** 14 - 1
-    assert_eq!(serialized_size(&vec![0u8; 16384][..]).unwrap(), 3 + 16384); // 2 ** 14
+    let a = vec![0u8; 127]; // 2 ** 7 - 1
+    let b = vec![0u8; 128]; // 2 ** 7
+    let c = vec![0u8; 16383]; // 2 ** 14 - 1
+    let d = vec![0u8; 16384]; // 2 ** 14
+
+    assert_eq!(serialized_size(&a[..]).unwrap(), 1 + 127); // 2 ** 7 - 1
+    assert_eq!(serialized_size(&b[..]).unwrap(), 2 + 128); // 2 ** 7
+    assert_eq!(serialized_size(&c[..]).unwrap(), 2 + 16383); // 2 ** 14 - 1
+    assert_eq!(serialized_size(&d[..]).unwrap(), 3 + 16384); // 2 ** 14
+
+    the_same(a);
+    the_same(b);
+    the_same(c);
+    the_same(d);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -17,6 +17,11 @@ use bincode::{
 };
 use serde::de::{Deserialize, DeserializeSeed, Deserializer, SeqAccess, Visitor};
 
+#[cfg(not(feature = "varint"))]
+const LEN_SIZE: u64 = 8;
+#[cfg(feature = "varint")]
+const LEN_SIZE: u64 = 1;
+
 fn the_same<V>(element: V)
 where
     V: serde::Serialize + serde::de::DeserializeOwned + PartialEq + Debug + 'static,
@@ -225,14 +230,19 @@ fn test_fixed_size_array() {
     the_same([0u8; 19]);
 }
 
-#[cfg(not(feature = "varint"))]
 #[test]
 fn deserializing_errors() {
     match *deserialize::<bool>(&vec![0xA][..]).unwrap_err() {
         ErrorKind::InvalidBoolEncoding(0xA) => {}
         _ => panic!(),
     }
-    match *deserialize::<String>(&vec![1, 0, 0, 0, 0, 0, 0, 0, 0xFF][..]).unwrap_err() {
+
+    #[cfg(not(feature = "varint"))]
+    let invalid_str = vec![1, 0, 0, 0, 0, 0, 0, 0, 0xFF];
+    #[cfg(feature = "varint")]
+    let invalid_str = vec![1, 0xFF];
+
+    match *deserialize::<String>(&invalid_str[..]).unwrap_err() {
         ErrorKind::InvalidUtf8Encoding(_) => {}
         _ => panic!(),
     }
@@ -244,38 +254,12 @@ fn deserializing_errors() {
         Two,
     };
 
-    match *deserialize::<Test>(&vec![0, 0, 0, 5][..]).unwrap_err() {
-        // Error message comes from serde
-        ErrorKind::Custom(_) => {}
-        _ => panic!(),
-    }
-    match *deserialize::<Option<u8>>(&vec![5, 0][..]).unwrap_err() {
-        ErrorKind::InvalidTagEncoding(_) => {}
-        _ => panic!(),
-    }
-}
+    #[cfg(not(feature = "varint"))]
+    let invalid_enum = vec![0, 0, 0, 5];
+    #[cfg(feature = "varint")]
+    let invalid_enum = vec![5];
 
-
-#[cfg(feature = "varint")]
-#[test]
-fn deserializing_errors() {
-    match *deserialize::<bool>(&vec![0xA][..]).unwrap_err() {
-        ErrorKind::InvalidBoolEncoding(0xA) => {}
-        _ => panic!(),
-    }
-    match *deserialize::<String>(&vec![1, 0xFF][..]).unwrap_err() {
-        ErrorKind::InvalidUtf8Encoding(_) => {}
-        _ => panic!(),
-    }
-
-    // Out-of-bounds variant
-    #[derive(Serialize, Deserialize, Debug)]
-    enum Test {
-        One,
-        Two,
-    };
-
-    match *deserialize::<Test>(&vec![5][..]).unwrap_err() {
+    match *deserialize::<Test>(&invalid_enum[..]).unwrap_err() {
         // Error message comes from serde
         ErrorKind::Custom(_) => {}
         _ => panic!(),
@@ -318,27 +302,15 @@ fn too_big_char_deserialize() {
     assert_eq!(deserialized.unwrap(), 'A');
 }
 
-#[cfg(not(feature = "varint"))]
 #[test]
 fn too_big_serialize() {
     assert!(config().limit(3).serialize(&0u32).is_err());
     assert!(config().limit(4).serialize(&0u32).is_ok());
 
-    assert!(config().limit(8 + 4).serialize(&"abcde").is_err());
-    assert!(config().limit(8 + 5).serialize(&"abcde").is_ok());
+    assert!(config().limit(LEN_SIZE + 4).serialize(&"abcde").is_err());
+    assert!(config().limit(LEN_SIZE + 5).serialize(&"abcde").is_ok());
 }
 
-#[cfg(feature = "varint")]
-#[test]
-fn too_big_serialize() {
-    assert!(config().limit(3).serialize(&0u32).is_err());
-    assert!(config().limit(4).serialize(&0u32).is_ok());
-
-    assert!(config().limit(1 + 4).serialize(&"abcde").is_err());
-    assert!(config().limit(1 + 5).serialize(&"abcde").is_ok());
-}
-
-#[cfg(not(feature = "varint"))]
 #[test]
 fn test_serialized_size() {
     assert!(serialized_size(&0u8).unwrap() == 1);
@@ -347,28 +319,12 @@ fn test_serialized_size() {
     assert!(serialized_size(&0u64).unwrap() == 8);
 
     // length isize stored as u64
-    assert!(serialized_size(&"").unwrap() == 8);
-    assert!(serialized_size(&"a").unwrap() == 8 + 1);
+    assert!(serialized_size(&"").unwrap() == LEN_SIZE);
+    assert!(serialized_size(&"a").unwrap() == LEN_SIZE + 1);
 
-    assert!(serialized_size(&vec![0u32, 1u32, 2u32]).unwrap() == 8 + 3 * (4));
+    assert!(serialized_size(&vec![0u32, 1u32, 2u32]).unwrap() == LEN_SIZE + 3 * (4));
 }
 
-#[cfg(feature = "varint")]
-#[test]
-fn test_serialized_size() {
-    assert!(serialized_size(&0u8).unwrap() == 1);
-    assert!(serialized_size(&0u16).unwrap() == 2);
-    assert!(serialized_size(&0u32).unwrap() == 4);
-    assert!(serialized_size(&0u64).unwrap() == 8);
-
-    // length isize stored as varint
-    assert!(serialized_size(&"").unwrap() == 1);
-    assert!(serialized_size(&"a").unwrap() == 1 + 1);
-
-    assert!(serialized_size(&vec![0u32, 1u32, 2u32]).unwrap() == 1 + 3 * (4));
-}
-
-#[cfg(not(feature = "varint"))]
 #[test]
 fn test_serialized_size_bounded() {
     // JUST RIGHT
@@ -376,57 +332,25 @@ fn test_serialized_size_bounded() {
     assert!(config().limit(2).serialized_size(&0u16).unwrap() == 2);
     assert!(config().limit(4).serialized_size(&0u32).unwrap() == 4);
     assert!(config().limit(8).serialized_size(&0u64).unwrap() == 8);
-    assert!(config().limit(8).serialized_size(&"").unwrap() == 8);
-    assert!(config().limit(8 + 1).serialized_size(&"a").unwrap() == 8 + 1);
+    assert!(config().limit(LEN_SIZE).serialized_size(&"").unwrap() == LEN_SIZE);
+    assert!(config().limit(LEN_SIZE + 1).serialized_size(&"a").unwrap() == LEN_SIZE + 1);
     assert!(
         config()
-            .limit(8 + 3 * 4)
+            .limit(LEN_SIZE + 3 * 4)
             .serialized_size(&vec![0u32, 1u32, 2u32])
             .unwrap()
-            == 8 + 3 * 4
+            == LEN_SIZE + 3 * 4
     );
     // Below
     assert!(config().limit(0).serialized_size(&0u8).is_err());
     assert!(config().limit(1).serialized_size(&0u16).is_err());
     assert!(config().limit(3).serialized_size(&0u32).is_err());
     assert!(config().limit(7).serialized_size(&0u64).is_err());
-    assert!(config().limit(7).serialized_size(&"").is_err());
-    assert!(config().limit(8 + 0).serialized_size(&"a").is_err());
+    assert!(config().limit(LEN_SIZE - 1).serialized_size(&"").is_err());
+    assert!(config().limit(LEN_SIZE + 0).serialized_size(&"a").is_err());
     assert!(
         config()
-            .limit(8 + 3 * 4 - 1)
-            .serialized_size(&vec![0u32, 1u32, 2u32])
-            .is_err()
-    );
-}
-
-#[cfg(feature = "varint")]
-#[test]
-fn test_serialized_size_bounded() {
-    // JUST RIGHT
-    assert!(config().limit(1).serialized_size(&0u8).unwrap() == 1);
-    assert!(config().limit(2).serialized_size(&0u16).unwrap() == 2);
-    assert!(config().limit(4).serialized_size(&0u32).unwrap() == 4);
-    assert!(config().limit(8).serialized_size(&0u64).unwrap() == 8);
-    assert!(config().limit(1).serialized_size(&"").unwrap() == 1);
-    assert!(config().limit(1 + 1).serialized_size(&"a").unwrap() == 1 + 1);
-    assert!(
-        config()
-            .limit(1 + 3 * 4)
-            .serialized_size(&vec![0u32, 1u32, 2u32])
-            .unwrap()
-            == 1 + 3 * 4
-    );
-    // Below
-    assert!(config().limit(0).serialized_size(&0u8).is_err());
-    assert!(config().limit(1).serialized_size(&0u16).is_err());
-    assert!(config().limit(3).serialized_size(&0u32).is_err());
-    assert!(config().limit(7).serialized_size(&0u64).is_err());
-    assert!(config().limit(0).serialized_size(&"").is_err());
-    assert!(config().limit(1 + 0).serialized_size(&"a").is_err());
-    assert!(
-        config()
-            .limit(1 + 3 * 4 - 1)
+            .limit(LEN_SIZE + 3 * 4 - 1)
             .serialized_size(&vec![0u32, 1u32, 2u32])
             .is_err()
     );
@@ -770,4 +694,13 @@ fn test_big_endian_deserialize_seed() {
     }
 
     assert_eq!(seed_data, (0..100).collect::<Vec<_>>());
+}
+
+#[cfg(feature = "varint")]
+#[test]
+fn test_varint_length_prefixes() {
+    assert_eq!(serialized_size(&vec![0u8; 127][..]).unwrap(), 1 + 127); // 2 ** 7 - 1
+    assert_eq!(serialized_size(&vec![0u8; 128][..]).unwrap(), 2 + 128); // 2 ** 7
+    assert_eq!(serialized_size(&vec![0u8; 16383][..]).unwrap(), 2 + 16383); // 2 ** 14 - 1
+    assert_eq!(serialized_size(&vec![0u8; 16384][..]).unwrap(), 3 + 16384); // 2 ** 14
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -225,6 +225,7 @@ fn test_fixed_size_array() {
     the_same([0u8; 19]);
 }
 
+#[cfg(not(feature = "varint"))]
 #[test]
 fn deserializing_errors() {
     match *deserialize::<bool>(&vec![0xA][..]).unwrap_err() {
@@ -244,6 +245,37 @@ fn deserializing_errors() {
     };
 
     match *deserialize::<Test>(&vec![0, 0, 0, 5][..]).unwrap_err() {
+        // Error message comes from serde
+        ErrorKind::Custom(_) => {}
+        _ => panic!(),
+    }
+    match *deserialize::<Option<u8>>(&vec![5, 0][..]).unwrap_err() {
+        ErrorKind::InvalidTagEncoding(_) => {}
+        _ => panic!(),
+    }
+}
+
+
+#[cfg(feature = "varint")]
+#[test]
+fn deserializing_errors() {
+    match *deserialize::<bool>(&vec![0xA][..]).unwrap_err() {
+        ErrorKind::InvalidBoolEncoding(0xA) => {}
+        _ => panic!(),
+    }
+    match *deserialize::<String>(&vec![1, 0xFF][..]).unwrap_err() {
+        ErrorKind::InvalidUtf8Encoding(_) => {}
+        _ => panic!(),
+    }
+
+    // Out-of-bounds variant
+    #[derive(Serialize, Deserialize, Debug)]
+    enum Test {
+        One,
+        Two,
+    };
+
+    match *deserialize::<Test>(&vec![5][..]).unwrap_err() {
         // Error message comes from serde
         ErrorKind::Custom(_) => {}
         _ => panic!(),
@@ -286,6 +318,7 @@ fn too_big_char_deserialize() {
     assert_eq!(deserialized.unwrap(), 'A');
 }
 
+#[cfg(not(feature = "varint"))]
 #[test]
 fn too_big_serialize() {
     assert!(config().limit(3).serialize(&0u32).is_err());
@@ -295,6 +328,17 @@ fn too_big_serialize() {
     assert!(config().limit(8 + 5).serialize(&"abcde").is_ok());
 }
 
+#[cfg(feature = "varint")]
+#[test]
+fn too_big_serialize() {
+    assert!(config().limit(3).serialize(&0u32).is_err());
+    assert!(config().limit(4).serialize(&0u32).is_ok());
+
+    assert!(config().limit(1 + 4).serialize(&"abcde").is_err());
+    assert!(config().limit(1 + 5).serialize(&"abcde").is_ok());
+}
+
+#[cfg(not(feature = "varint"))]
 #[test]
 fn test_serialized_size() {
     assert!(serialized_size(&0u8).unwrap() == 1);
@@ -309,6 +353,22 @@ fn test_serialized_size() {
     assert!(serialized_size(&vec![0u32, 1u32, 2u32]).unwrap() == 8 + 3 * (4));
 }
 
+#[cfg(feature = "varint")]
+#[test]
+fn test_serialized_size() {
+    assert!(serialized_size(&0u8).unwrap() == 1);
+    assert!(serialized_size(&0u16).unwrap() == 2);
+    assert!(serialized_size(&0u32).unwrap() == 4);
+    assert!(serialized_size(&0u64).unwrap() == 8);
+
+    // length isize stored as varint
+    assert!(serialized_size(&"").unwrap() == 1);
+    assert!(serialized_size(&"a").unwrap() == 1 + 1);
+
+    assert!(serialized_size(&vec![0u32, 1u32, 2u32]).unwrap() == 1 + 3 * (4));
+}
+
+#[cfg(not(feature = "varint"))]
 #[test]
 fn test_serialized_size_bounded() {
     // JUST RIGHT
@@ -335,6 +395,38 @@ fn test_serialized_size_bounded() {
     assert!(
         config()
             .limit(8 + 3 * 4 - 1)
+            .serialized_size(&vec![0u32, 1u32, 2u32])
+            .is_err()
+    );
+}
+
+#[cfg(feature = "varint")]
+#[test]
+fn test_serialized_size_bounded() {
+    // JUST RIGHT
+    assert!(config().limit(1).serialized_size(&0u8).unwrap() == 1);
+    assert!(config().limit(2).serialized_size(&0u16).unwrap() == 2);
+    assert!(config().limit(4).serialized_size(&0u32).unwrap() == 4);
+    assert!(config().limit(8).serialized_size(&0u64).unwrap() == 8);
+    assert!(config().limit(1).serialized_size(&"").unwrap() == 1);
+    assert!(config().limit(1 + 1).serialized_size(&"a").unwrap() == 1 + 1);
+    assert!(
+        config()
+            .limit(1 + 3 * 4)
+            .serialized_size(&vec![0u32, 1u32, 2u32])
+            .unwrap()
+            == 1 + 3 * 4
+    );
+    // Below
+    assert!(config().limit(0).serialized_size(&0u8).is_err());
+    assert!(config().limit(1).serialized_size(&0u16).is_err());
+    assert!(config().limit(3).serialized_size(&0u32).is_err());
+    assert!(config().limit(7).serialized_size(&0u64).is_err());
+    assert!(config().limit(0).serialized_size(&"").is_err());
+    assert!(config().limit(1 + 0).serialized_size(&"a").is_err());
+    assert!(
+        config()
+            .limit(1 + 3 * 4 - 1)
             .serialized_size(&vec![0u32, 1u32, 2u32])
             .is_err()
     );


### PR DESCRIPTION
Resolves #157, resolves #75.

Varint support needs to be enabled with the `varint` feature, it only affects enum tags and sequence lengths, all fixed size ints travel over the wire without alterations.

The particular encoding is pretty straight forward: while `n` is greater then `127` keep taking lowest 7 bits and serialize them as `u8` with significant bit set to `1`, final byte is always encoded without significant bit. Varint ignores the endianess setting, partly because I think it's unnecessary in this case, partly because I didn't want to wrap my head around it and potentially introduce weird cases where the first byte for a value `>= 128` lacks significant bit set. I didn't bother to check which direction ProtoBuf or Go varint does things, if it's different I can change it.

#167 can still technically be done as I don't verify that varints are encoded to their smallest possible representation.