### PR TITLE
Add more ..._seed variants of deserialize methods

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -290,6 +290,18 @@ impl Config {
         config_map!(self, opts => ::internal::deserialize_from(reader, opts))
     }
 
+    /// Deserializes an object directly from a `Read`er with state `seed` using this configuration
+    ///
+    /// If this returns an `Error`, `reader` may be in an invalid state.
+    #[inline(always)]
+    pub fn deserialize_from_seed<'a, R: Read, T: serde::de::DeserializeSeed<'a>>(
+        &self,
+        seed: T,
+        reader: R,
+    ) -> Result<T::Value> {
+        config_map!(self, opts => ::internal::deserialize_from_seed(seed, reader, opts))
+    }
+
     /// Deserializes an object from a custom `BincodeRead`er using the default configuration.
     /// It is highly recommended to use `deserialize_from` unless you need to implement
     /// `BincodeRead` for performance reasons.
@@ -301,6 +313,24 @@ impl Config {
         reader: R,
     ) -> Result<T> {
         config_map!(self, opts => ::internal::deserialize_from_custom(reader, opts))
+    }
+
+    /// Deserializes an object from a custom `BincodeRead`er with state `seed` using the default
+    /// configuration. It is highly recommended to use `deserialize_from` unless you need to
+    /// implement `BincodeRead` for performance reasons.
+    ///
+    /// If this returns an `Error`, `reader` may be in an invalid state.
+    #[inline(always)]
+    pub fn deserialize_from_custom_seed<
+        'a,
+        R: BincodeRead<'a>,
+        T: serde::de::DeserializeSeed<'a>,
+    >(
+        &self,
+        seed: T,
+        reader: R,
+    ) -> Result<T::Value> {
+        config_map!(self, opts => ::internal::deserialize_from_custom_seed(seed, reader, opts))
     }
 
     /// Executes the acceptor with a serde::Deserializer instance.

--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -150,13 +150,13 @@ where
     }
 }
 
-impl<R> BincodeRead<'static> for IoReader<R>
+impl<'a, R> BincodeRead<'a> for IoReader<R>
 where
     R: io::Read,
 {
     fn forward_read_str<V>(&mut self, length: usize, visitor: V) -> Result<V::Value>
     where
-        V: serde::de::Visitor<'static>,
+        V: serde::de::Visitor<'a>,
     {
         self.fill_buffer(length)?;
 
@@ -176,7 +176,7 @@ where
 
     fn forward_read_bytes<V>(&mut self, length: usize, visitor: V) -> Result<V::Value>
     where
-        V: serde::de::Visitor<'static>,
+        V: serde::de::Visitor<'a>,
     {
         self.fill_buffer(length)?;
         let r = visitor.visit_bytes(&self.temp_buffer[..]);

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,5 +1,6 @@
 use serde;
 use std::io::{Read, Write};
+use std::marker::PhantomData;
 
 use config::{Options, OptionsExt};
 use de::read::BincodeRead;
@@ -78,9 +79,17 @@ where
     T: serde::de::DeserializeOwned,
     O: Options,
 {
+    deserialize_from_seed(PhantomData, reader, options)
+}
+
+pub(crate) fn deserialize_from_seed<'a, R, T, O>(seed: T, reader: R, options: O) -> Result<T::Value>
+where
+    R: Read,
+    T: serde::de::DeserializeSeed<'a>,
+    O: Options,
+{
     let reader = ::de::read::IoReader::new(reader);
-    let mut deserializer = ::de::Deserializer::<_, O>::new(reader, options);
-    serde::Deserialize::deserialize(&mut deserializer)
+    deserialize_from_custom_seed(seed, reader, options)
 }
 
 pub(crate) fn deserialize_from_custom<'a, R, T, O>(reader: R, options: O) -> Result<T>
@@ -89,8 +98,21 @@ where
     T: serde::de::DeserializeOwned,
     O: Options,
 {
+    deserialize_from_custom_seed(PhantomData, reader, options)
+}
+
+pub(crate) fn deserialize_from_custom_seed<'a, R, T, O>(
+    seed: T,
+    reader: R,
+    options: O,
+) -> Result<T::Value>
+where
+    R: BincodeRead<'a>,
+    T: serde::de::DeserializeSeed<'a>,
+    O: Options,
+{
     let mut deserializer = ::de::Deserializer::<_, O>::new(reader, options);
-    serde::Deserialize::deserialize(&mut deserializer)
+    seed.deserialize(&mut deserializer)
 }
 
 pub(crate) fn deserialize_in_place<'a, R, T, O>(reader: R, options: O, place: &mut T) -> Result<()>
@@ -108,10 +130,7 @@ where
     T: serde::de::Deserialize<'a>,
     O: Options,
 {
-    let reader = ::de::read::SliceReader::new(bytes);
-    let options = ::config::WithOtherLimit::new(options, Infinite);
-    let mut deserializer = ::de::Deserializer::new(reader, options);
-    serde::Deserialize::deserialize(&mut deserializer)
+    deserialize_seed(PhantomData, bytes, options)
 }
 
 pub(crate) fn deserialize_seed<'a, T, O>(seed: T, bytes: &'a [u8], options: O) -> Result<T::Value>
@@ -121,8 +140,7 @@ where
 {
     let reader = ::de::read::SliceReader::new(bytes);
     let options = ::config::WithOtherLimit::new(options, Infinite);
-    let mut deserializer = ::de::Deserializer::new(reader, options);
-    seed.deserialize(&mut deserializer)
+    deserialize_from_custom_seed(seed, reader, options)
 }
 
 pub(crate) trait SizeLimit: Clone {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -679,3 +679,40 @@ fn test_big_endian_deserialize_seed() {
 
     assert_eq!(seed_data, (0..100).collect::<Vec<_>>());
 }
+
+#[test]
+fn test_default_deserialize_from_seed() {
+    let config = config();
+
+    let data: Vec<_> = (10..100).collect();
+    let bytes = config.serialize(&data).expect("Config::serialize failed");
+
+    let mut seed_data: Vec<_> = (0..10).collect();
+    {
+        let seed = ExtendVec(&mut seed_data);
+        config
+            .deserialize_from_seed(seed, &mut &*bytes)
+            .expect("Config::deserialize_from_seed failed");
+    }
+
+    assert_eq!(seed_data, (0..100).collect::<Vec<_>>());
+}
+
+#[test]
+fn test_big_endian_deserialize_from_seed() {
+    let mut config = config();
+    config.big_endian();
+
+    let data: Vec<_> = (10..100).collect();
+    let bytes = config.serialize(&data).expect("Config::serialize failed");
+
+    let mut seed_data: Vec<_> = (0..10).collect();
+    {
+        let seed = ExtendVec(&mut seed_data);
+        config
+            .deserialize_from_seed(seed, &mut &*bytes)
+            .expect("Config::deserialize_from_seed failed");
+    }
+
+    assert_eq!(seed_data, (0..100).collect::<Vec<_>>());
+}


### PR DESCRIPTION
This PR builds on https://github.com/servo/bincode/pull/246 to add `Config::deserialize_from_seed` and `Config::deserialize_from_custom_seed`. The current `Config::deserialize_seed` accepts `& [u8]`; these new methods add support for `R: Read` and `R: BincodeRead<'a>` as well.

There are two changes in addition:
* `deserialize_from_seed` required the `IoReader` struct's impl of `BincodeRead<'static>` to be broadened to `for<'a> BincodeRead<'a>`;
* The 7 `deserialize*` methods ended up with quite a bit of duplication so I tried to minimise this by implementing them in terms of each other.