### PR TITLE
Fix emscripten build failures due to lack of i128 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ documentation = "https://docs.rs/bincode"
 readme = "./readme.md"
 categories = ["encoding", "network-programming"]
 keywords = ["binary", "encode", "decode", "serialize", "deserialize"]
-build = "build.rs"
 
 license = "MIT"
 description = "A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!"
@@ -24,13 +23,11 @@ serde = "1.0.63"
 serde_bytes = "0.11"
 serde_derive = "1.0.27"
 
-[build-dependencies]
-autocfg = "0.1.2"
-
 [features]
-# This feature is no longer used and is DEPRECATED. This crate now
-# automatically enables i128 support for Rust compilers that support it. The
-# feature will be removed if and when a new major version is released.
+# This feature is no longer used and is DEPRECATED. This crate relies on the
+# serde `serde_if_integer128` macro to enable i128 support for Rust compilers
+# and targets that support it. The feature will be removed if and when a new
+# major version is released.
 i128 = []
 
 [badges]

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,0 @@
-extern crate autocfg;
-
-fn main() {
-    autocfg::rerun_path(file!());
-
-    let ac = autocfg::new();
-    ac.emit_has_type("i128");
-}

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -108,30 +108,9 @@ where
     impl_nums!(f32, deserialize_f32, visit_f32, read_f32);
     impl_nums!(f64, deserialize_f64, visit_f64, read_f64);
 
-    #[cfg(has_i128)]
-    impl_nums!(u128, deserialize_u128, visit_u128, read_u128);
-
-    #[cfg(has_i128)]
-    impl_nums!(i128, deserialize_i128, visit_i128, read_i128);
-
     serde_if_integer128! {
-        #[cfg(not(has_i128))]
-        fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
-        where
-            V: serde::de::Visitor<'de>
-        {
-            let _ = visitor;
-            Err(DeError::custom("u128 is not supported. Use Rustc ≥ 1.26."))
-        }
-
-        #[cfg(not(has_i128))]
-        fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
-        where
-            V: serde::de::Visitor<'de>
-        {
-            let _ = visitor;
-            Err(DeError::custom("i128 is not supported. Use Rustc ≥ 1.26."))
-        }
+        impl_nums!(u128, deserialize_u128, visit_u128, read_u128);
+        impl_nums!(i128, deserialize_i128, visit_i128, read_i128);
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! ### 128bit numbers
 //!
 //! Support for `i128` and `u128` is automatically enabled on Rust toolchains
-//! greater than or equal to `1.26.0`.
+//! greater than or equal to `1.26.0` and disabled for targets which do not support it
 
 #![doc(html_root_url = "https://docs.rs/bincode/1.2.0")]
 #![crate_name = "bincode"]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -88,31 +88,13 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
         self.writer.write_i64::<O::Endian>(v).map_err(Into::into)
     }
 
-    #[cfg(has_i128)]
-    fn serialize_u128(self, v: u128) -> Result<()> {
-        self.writer.write_u128::<O::Endian>(v).map_err(Into::into)
-    }
-
-    #[cfg(has_i128)]
-    fn serialize_i128(self, v: i128) -> Result<()> {
-        self.writer.write_i128::<O::Endian>(v).map_err(Into::into)
-    }
-
     serde_if_integer128! {
-        #[cfg(not(has_i128))]
         fn serialize_u128(self, v: u128) -> Result<()> {
-            use serde::ser::Error;
-
-            let _ = v;
-            Err(Error::custom("u128 is not supported. Use Rustc ≥ 1.26."))
+            self.writer.write_u128::<O::Endian>(v).map_err(Into::into)
         }
 
-        #[cfg(not(has_i128))]
         fn serialize_i128(self, v: i128) -> Result<()> {
-            use serde::ser::Error;
-
-            let _ = v;
-            Err(Error::custom("i128 is not supported. Use Rustc ≥ 1.26."))
+            self.writer.write_i128::<O::Endian>(v).map_err(Into::into)
         }
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,6 +3,7 @@ extern crate serde_derive;
 
 extern crate bincode;
 extern crate byteorder;
+#[macro_use]
 extern crate serde;
 extern crate serde_bytes;
 
@@ -72,18 +73,19 @@ fn test_numbers() {
     the_same(5f64);
 }
 
-#[cfg(has_i128)]
-#[test]
-fn test_numbers_128bit() {
-    // unsigned positive
-    the_same(5u128);
-    the_same(u128::max_value());
-    // signed positive
-    the_same(5i128);
-    the_same(i128::max_value());
-    // signed negative
-    the_same(-5i128);
-    the_same(i128::min_value());
+serde_if_integer128! {
+    #[test]
+    fn test_numbers_128bit() {
+        // unsigned positive
+        the_same(5u128);
+        the_same(u128::max_value());
+        // signed positive
+        the_same(5i128);
+        the_same(i128::max_value());
+        // signed negative
+        the_same(-5i128);
+        the_same(i128::min_value());
+    }
 }
 
 #[test]


### PR DESCRIPTION
#### Problem
Bincode only partially relies on whether `serde` decides to enable `i128`. And so, building `bincode` for  Emscripten targets is totally broken on `rustc` >= 1.26.0.

#### Solution
Remove `autocfg` and simply rely on `serde` to determine whether i128 is supported

#### Background
`autocfg` checks for `i128` support by attempting to compile code to llvm-ir and checking for success or failure. When targeting Emscripten, `i128` can still be compiled to llvm-ir and so `autocfg` believes `i128` support should be enabled. Unfortunately, the Emscripten runtime does not support `i128` despite the LLVM backend supporting it and so it needs to be explicitly disabled. This is the route that `serde` takes here: https://github.com/serde-rs/serde/blob/master/serde/build.rs#L56

Since serde does not add the `deserialize_u128` method to the `serde::Deserializer` trait for Emscripten targets, but `autocfg` believes that 128bit integers are supported and implements the method, I'm seeing this build error:

```
error[E0407]: method `deserialize_u128` is not a member of trait `serde::Deserializer`
   --> /Users/jstarry/Workspace/bincode/src/de/mod.rs:65:9
    |
65  | /         fn $dser_method<V>(self, visitor: V) -> Result<V::Value>
66  | |             where V: serde::de::Visitor<'de>,
67  | |         {
68  | |             try!(self.read_type::<$ty>());
69  | |             let value = try!(self.reader.$reader_method::<O::Endian>());
70  | |             visitor.$visitor_method(value)
71  | |         }
    | |_________^ not a member of trait `serde::Deserializer`
...
112 |       impl_nums!(u128, deserialize_u128, visit_u128, read_u128);
    |       ---------------------------------------------------------- in this macro invocation
```

Full CI Failure here: https://travis-ci.com/yewstack/yew/jobs/247388659#L541