### PR TITLE
Issue #285: Add support for lengths other than 64 bits.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -96,11 +96,16 @@ enum EndianOption {
     Native,
 }
 
+/// Used to specify the unit used for length of strings and arrays via `config.string_length` or `config.array_length`.
 #[derive(Clone, Copy)]
 pub enum LengthOption {
+    ///64 unsigned bits
     U64,
+    ///32 unsigned bits
     U32,
+    ///16 unsigned bits
     U16,
+    ///8 unsigned bits
     U8,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use super::internal::{Bounded, Infinite, SizeLimit, SizeType, U8, U16, U32, U64};
+use super::internal::{Bounded, Infinite, SizeLimit, SizeType, U16, U32, U64, U8};
 use byteorder::{BigEndian, ByteOrder, LittleEndian, NativeEndian};
 use de::read::BincodeRead;
 use error::Result;
@@ -42,11 +42,17 @@ pub(crate) trait OptionsExt: Options + Sized {
         WithOtherEndian::new(self)
     }
 
-    fn with_string_size<S>(self) -> WithOtherStringLength<Self, S> where S: SizeType {
+    fn with_string_size<S>(self) -> WithOtherStringLength<Self, S>
+    where
+        S: SizeType,
+    {
         WithOtherStringLength::new(self)
     }
 
-    fn with_array_size<S>(self) -> WithOtherArrayLength<Self, S> where S: SizeType {
+    fn with_array_size<S>(self) -> WithOtherArrayLength<Self, S>
+    where
+        S: SizeType,
+    {
         WithOtherArrayLength::new(self)
     }
 }
@@ -108,7 +114,6 @@ pub enum LengthOption {
     ///8 unsigned bits
     U8,
 }
-
 
 /// A configuration builder whose options Bincode will use
 /// while serializing and deserializing.
@@ -255,7 +260,7 @@ macro_rules! config_map_limit {
                 $call
             }
         }
-    }
+    };
 }
 
 macro_rules! config_map_endian {
@@ -274,7 +279,7 @@ macro_rules! config_map_endian {
                 $call
             }
         }
-    }
+    };
 }
 
 macro_rules! config_map_string_length {
@@ -297,7 +302,7 @@ macro_rules! config_map_string_length {
                 $call
             }
         }
-    }
+    };
 }
 
 macro_rules! config_map_array_length {
@@ -320,7 +325,7 @@ macro_rules! config_map_array_length {
                 $call
             }
         }
-    }
+    };
 }
 
 macro_rules! config_map {

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,9 +7,6 @@ use std::io::{Read, Write};
 use std::marker::PhantomData;
 use {DeserializerAcceptor, SerializerAcceptor};
 
-use self::EndianOption::*;
-use self::LimitOption::*;
-
 struct DefaultOptions(Infinite);
 
 pub(crate) trait Options {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,6 +1,6 @@
 use config::Options;
-use std::convert::TryInto;
 use std::io::Read;
+use super::try_into::*;
 
 use self::read::BincodeRead;
 use byteorder::ReadBytesExt;

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -50,14 +50,14 @@ impl<'de, R: BincodeRead<'de>, O: Options> Deserializer<R, O> {
     }
 
     fn read_vec(&mut self) -> Result<Vec<u8>> {
-        let len = O::ArraySize::read(|| serde::Deserialize::deserialize(&mut *self))?;
+        let len = O::ArraySize::read(&mut || serde::Deserialize::deserialize(&mut *self))?;
         self.read_bytes(len)?;
         let len: usize = len.try_into().map_err(|_e| ErrorKind::SizeLimit)?;
         self.reader.get_byte_buffer(len)
     }
 
     fn read_string(&mut self) -> Result<String> {
-        let len = O::StringSize::read(|| serde::Deserialize::deserialize(&mut *self))?;
+        let len = O::StringSize::read(&mut || serde::Deserialize::deserialize(&mut *self))?;
         self.read_bytes(len)?;
         let len: usize = len.try_into().map_err(|_e| ErrorKind::SizeLimit)?;
         let vec = self.reader.get_byte_buffer(len)?;
@@ -200,7 +200,7 @@ where
     where
         V: serde::de::Visitor<'de>,
     {
-        let len = O::StringSize::read(|| serde::Deserialize::deserialize(&mut *self))?;
+        let len = O::StringSize::read(&mut || serde::Deserialize::deserialize(&mut *self))?;
         try!(self.read_bytes(len));
         let len: usize = len.try_into().map_err(|_e| ErrorKind::SizeLimit)?;
         self.reader.forward_read_str(len, visitor)
@@ -217,7 +217,7 @@ where
     where
         V: serde::de::Visitor<'de>,
     {
-        let len = O::ArraySize::read(|| serde::Deserialize::deserialize(&mut *self))?;
+        let len = O::ArraySize::read(&mut || serde::Deserialize::deserialize(&mut *self))?;
         try!(self.read_bytes(len));
         let len: usize = len.try_into().map_err(|_e| ErrorKind::SizeLimit)?;
         self.reader.forward_read_bytes(len, visitor)
@@ -317,7 +317,7 @@ where
     where
         V: serde::de::Visitor<'de>,
     {
-        let len = O::ArraySize::read(|| serde::Deserialize::deserialize(&mut *self))?;
+        let len = O::ArraySize::read(&mut || serde::Deserialize::deserialize(&mut *self))?;
         let len: usize = len.try_into().map_err(|_e| ErrorKind::SizeLimit)?;
         self.deserialize_tuple(len, visitor)
     }
@@ -368,7 +368,7 @@ where
             }
         }
 
-        let len = O::ArraySize::read(|| serde::Deserialize::deserialize(&mut *self))?;
+        let len = O::ArraySize::read(&mut || serde::Deserialize::deserialize(&mut *self))?;
         let len: usize = len.try_into().map_err(|_e| ErrorKind::SizeLimit)?;
         visitor.visit_map(Access {
             deserializer: self,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,6 +1,6 @@
 use config::Options;
-use std::io::Read;
 use std::convert::TryInto;
+use std::io::Read;
 
 use self::read::BincodeRead;
 use byteorder::ReadBytesExt;
@@ -189,12 +189,10 @@ where
             return Err(error());
         }
 
-        let res = try!(
-            str::from_utf8(&buf[..width])
-                .ok()
-                .and_then(|s| s.chars().next())
-                .ok_or(error())
-        );
+        let res = try!(str::from_utf8(&buf[..width])
+            .ok()
+            .and_then(|s| s.chars().next())
+            .ok_or(error()));
         visitor.visit_char(res)
     }
 

--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -145,9 +145,7 @@ where
         // Then create a slice with the length as our desired length. This is
         // safe as long as we only write (no reads) to this buffer, because
         // `reserve_exact` above has allocated this space.
-        let buf = unsafe {
-            slice::from_raw_parts_mut(self.temp_buffer.as_mut_ptr(), length)
-        };
+        let buf = unsafe { slice::from_raw_parts_mut(self.temp_buffer.as_mut_ptr(), length) };
 
         // This method is assumed to properly handle slices which include
         // uninitialized bytes (as ours does). See discussion at the link below.

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,7 +63,7 @@ impl StdError for ErrorKind {
         }
     }
 
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn cause(&self) -> Option<&error::Error> {
         match *self {
             ErrorKind::Io(ref err) => Some(err),
             ErrorKind::InvalidUtf8Encoding(_) => None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,8 @@ pub enum ErrorKind {
     /// If (de)serializing a message takes more than the provided size limit, this
     /// error is returned.
     SizeLimit,
+    /// If serializing a string/vec/array requires more bytes to represent the size than the config allows.
+    SizeTypeLimit,
     /// Bincode can not encode sequences of unknown length (like iterators).
     SequenceMustHaveLength,
     /// A custom error message from Serde.
@@ -54,6 +56,7 @@ impl StdError for ErrorKind {
                 "Bincode doesn't support serde::Deserializer::deserialize_any"
             }
             ErrorKind::SizeLimit => "the size limit has been reached",
+            ErrorKind::SizeTypeLimit => "the size is larger than can be represented with this config",
             ErrorKind::Custom(ref msg) => msg,
         }
     }
@@ -68,6 +71,7 @@ impl StdError for ErrorKind {
             ErrorKind::SequenceMustHaveLength => None,
             ErrorKind::DeserializeAnyNotSupported => None,
             ErrorKind::SizeLimit => None,
+            ErrorKind::SizeTypeLimit => None,
             ErrorKind::Custom(_) => None,
         }
     }
@@ -93,6 +97,7 @@ impl fmt::Display for ErrorKind {
             }
             ErrorKind::SequenceMustHaveLength => write!(fmt, "{}", self.description()),
             ErrorKind::SizeLimit => write!(fmt, "{}", self.description()),
+            ErrorKind::SizeTypeLimit => write!(fmt, "{}", self.description()),
             ErrorKind::DeserializeAnyNotSupported => write!(
                 fmt,
                 "Bincode does not support the serde::Deserializer::deserialize_any method"

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,7 +56,9 @@ impl StdError for ErrorKind {
                 "Bincode doesn't support serde::Deserializer::deserialize_any"
             }
             ErrorKind::SizeLimit => "the size limit has been reached",
-            ErrorKind::SizeTypeLimit => "the size is larger than can be represented with this config",
+            ErrorKind::SizeTypeLimit => {
+                "the size is larger than can be represented with this config"
+            }
             ErrorKind::Custom(ref msg) => msg,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,7 +63,7 @@ impl StdError for ErrorKind {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             ErrorKind::Io(ref err) => Some(err),
             ErrorKind::InvalidUtf8Encoding(_) => None,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -204,7 +204,7 @@ pub(crate) trait SizeType: Clone {
         S: serde::Serializer,
         Box<ErrorKind>: From<S::Error>,
     {
-        let value: Self::Primitive = value.try_into().map_err(|e| ErrorKind::SizeTypeLimit)?;
+        let value: Self::Primitive = value.try_into().map_err(|_e| ErrorKind::SizeTypeLimit)?;
         Self::write_to(writer, value)
     }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -4,8 +4,8 @@ use std::marker::PhantomData;
 
 use config::{Options, OptionsExt};
 use de::read::BincodeRead;
+use std::convert::{TryFrom, TryInto};
 use {ErrorKind, Result};
-use std::convert::{TryInto, TryFrom};
 
 #[derive(Clone)]
 struct CountSize<L: SizeLimit> {
@@ -192,7 +192,7 @@ impl SizeLimit for Infinite {
 }
 
 pub(crate) trait SizeType: Clone {
-    type Primitive : serde::de::DeserializeOwned + TryFrom<usize> + Into<u64>;
+    type Primitive: serde::de::DeserializeOwned + TryFrom<usize> + Into<u64>;
 
     fn read(mut reader: impl FnMut() -> Result<Self::Primitive>) -> Result<u64> {
         let result: Self::Primitive = reader()?;
@@ -200,14 +200,18 @@ pub(crate) trait SizeType: Clone {
     }
 
     fn write<S>(writer: S, value: usize) -> Result<S::Ok>
-        where S: serde::Serializer,
-              Box<ErrorKind>: From<S::Error>  {
+    where
+        S: serde::Serializer,
+        Box<ErrorKind>: From<S::Error>,
+    {
         let value: Self::Primitive = value.try_into().map_err(|e| ErrorKind::SizeTypeLimit)?;
         Self::write_to(writer, value)
     }
 
     fn write_to<S>(writer: S, value: Self::Primitive) -> Result<S::Ok>
-        where  S: serde::Serializer, Box<ErrorKind>: From<S::Error> ;
+    where
+        S: serde::Serializer,
+        Box<ErrorKind>: From<S::Error>;
 }
 
 /// An 8 byte length
@@ -216,7 +220,10 @@ pub struct U64;
 impl SizeType for U64 {
     type Primitive = u64;
     fn write_to<S>(writer: S, value: Self::Primitive) -> Result<S::Ok>
-        where  S: serde::Serializer, Box<ErrorKind>: From<S::Error> {
+    where
+        S: serde::Serializer,
+        Box<ErrorKind>: From<S::Error>,
+    {
         writer.serialize_u64(value).map_err(Into::into)
     }
 }
@@ -227,7 +234,10 @@ pub struct U32;
 impl SizeType for U32 {
     type Primitive = u32;
     fn write_to<S>(writer: S, value: Self::Primitive) -> Result<S::Ok>
-        where  S: serde::Serializer, Box<ErrorKind>: From<S::Error> {
+    where
+        S: serde::Serializer,
+        Box<ErrorKind>: From<S::Error>,
+    {
         writer.serialize_u32(value).map_err(Into::into)
     }
 }
@@ -238,7 +248,10 @@ pub struct U16;
 impl SizeType for U16 {
     type Primitive = u16;
     fn write_to<S>(writer: S, value: Self::Primitive) -> Result<S::Ok>
-        where  S: serde::Serializer, Box<ErrorKind>: From<S::Error> {
+    where
+        S: serde::Serializer,
+        Box<ErrorKind>: From<S::Error>,
+    {
         writer.serialize_u16(value).map_err(Into::into)
     }
 }
@@ -249,7 +262,10 @@ pub struct U8;
 impl SizeType for U8 {
     type Primitive = u8;
     fn write_to<S>(writer: S, value: Self::Primitive) -> Result<S::Ok>
-        where  S: serde::Serializer, Box<ErrorKind>: From<S::Error> {
+    where
+        S: serde::Serializer,
+        Box<ErrorKind>: From<S::Error>,
+    {
         writer.serialize_u8(value).map_err(Into::into)
     }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -189,3 +189,25 @@ impl SizeLimit for Infinite {
         None
     }
 }
+
+pub(crate) trait SizeType: Clone{}
+
+/// An 8 byte length
+#[derive(Copy, Clone)]
+pub struct U64;
+impl SizeType for U64{}
+
+/// A 4 byte length
+#[derive(Copy, Clone)]
+pub struct U32;
+impl SizeType for U32{}
+
+/// A 2 byte length
+#[derive(Copy, Clone)]
+pub struct U16;
+impl SizeType for U16{}
+
+/// A 1 byte length
+#[derive(Copy, Clone)]
+pub struct U8;
+impl SizeType for U8{}

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -194,7 +194,7 @@ impl SizeLimit for Infinite {
 pub(crate) trait SizeType: Clone {
     type Primitive: serde::de::DeserializeOwned + TryFrom<usize> + Into<u64>;
 
-    fn read(mut reader: impl FnMut() -> Result<Self::Primitive>) -> Result<u64> {
+    fn read(reader: &mut FnMut() -> Result<Self::Primitive>) -> Result<u64> {
         let result: Self::Primitive = reader()?;
         Ok(result.into())
     }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -4,8 +4,8 @@ use std::marker::PhantomData;
 
 use config::{Options, OptionsExt};
 use de::read::BincodeRead;
-use std::convert::{TryFrom, TryInto};
 use {ErrorKind, Result};
+use try_into::*;
 
 #[derive(Clone)]
 struct CountSize<L: SizeLimit> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod de;
 mod error;
 mod internal;
 mod ser;
+mod try_into;
 
 pub use config::{Config, LengthOption};
 pub use de::read::{BincodeRead, IoReader, SliceReader};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ mod error;
 mod internal;
 mod ser;
 
-pub use config::Config;
+pub use config::{Config, LengthOption};
 pub use de::read::{BincodeRead, IoReader, SliceReader};
 pub use error::{Error, ErrorKind, Result};
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -126,7 +126,6 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
         self.writer.write_f64::<O::Endian>(v).map_err(Into::into)
     }
 
-
     fn serialize_str(self, v: &str) -> Result<()> {
         let ser = &mut *self;
         O::StringSize::write(ser, v.len())?;

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -247,7 +247,7 @@ pub(crate) struct SizeChecker<O: Options> {
 }
 
 impl<O: Options> SizeChecker<O> {
-    
+
     fn add_raw(&mut self, size: u64) -> Result<()> {
         self.options.limit().add(size)
     }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -126,8 +126,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
-        let ser = &mut *self;
-        O::StringSize::write(ser, v.len())?;
+        O::StringSize::write(&mut *self, v.len())?;
         self.writer.write_all(v.as_bytes()).map_err(Into::into)
     }
 
@@ -138,8 +137,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<()> {
-        let ser = &mut *self;
-        O::ArraySize::write(ser, v.len())?;
+        O::ArraySize::write(&mut *self, v.len())?;
         self.writer.write_all(v).map_err(Into::into)
     }
 
@@ -157,8 +155,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
         let len = len.ok_or(ErrorKind::SequenceMustHaveLength)?;
-        let ser = &mut *self;
-        O::ArraySize::write(ser, len)?;
+        O::ArraySize::write(&mut *self, len)?;
         Ok(Compound { ser: self })
     }
 
@@ -187,8 +184,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
         let len = len.ok_or(ErrorKind::SequenceMustHaveLength)?;
-        let ser = &mut *self;
-        O::ArraySize::write(ser, len)?;
+        O::ArraySize::write(&mut *self, len)?;
         Ok(Compound { ser: self })
     }
 
@@ -332,8 +328,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
-        let ser = &mut *self;
-        O::StringSize::write(ser, v.len())?;
+        O::StringSize::write(&mut *self, v.len())?;
         self.add_raw(v.len() as u64)
     }
 
@@ -342,8 +337,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<()> {
-        let ser = &mut *self;
-        O::ArraySize::write(ser, v.len())?;
+        O::ArraySize::write(&mut *self, v.len())?;
         self.add_raw(v.len() as u64)
     }
 
@@ -361,8 +355,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
         let len = len.ok_or(ErrorKind::SequenceMustHaveLength)?;
-        let ser = &mut *self;
-        O::ArraySize::write(ser, len)?;
+        O::ArraySize::write(&mut *self, len)?;
         Ok(SizeCompound { ser: self })
     }
 
@@ -391,8 +384,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
         let len = len.ok_or(ErrorKind::SequenceMustHaveLength)?;
-        let ser = &mut *self;
-        O::ArraySize::write(ser, len)?;
+        O::ArraySize::write(&mut *self, len)?;
         Ok(SizeCompound { ser: self })
     }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -9,7 +9,6 @@ use super::internal::SizeLimit;
 use super::internal::SizeType;
 use super::{Error, ErrorKind, Result};
 use config::Options;
-use std::convert::TryInto;
 
 /// An Serializer that encodes values directly into a Writer.
 ///
@@ -248,10 +247,7 @@ pub(crate) struct SizeChecker<O: Options> {
 }
 
 impl<O: Options> SizeChecker<O> {
-    pub fn new(options: O) -> SizeChecker<O> {
-        SizeChecker { options: options }
-    }
-
+    
     fn add_raw(&mut self, size: u64) -> Result<()> {
         self.options.limit().add(size)
     }

--- a/src/try_into.rs
+++ b/src/try_into.rs
@@ -1,0 +1,225 @@
+///For whatever reason bincode is stuck in Rust 1.18, so this module replicates some of the
+///functionality of try_from / try_into from the standard library. THERE IS NO ORIGINAL CODE HERE
+pub(crate) trait TryFrom<T>: Sized {
+    /// The type returned in the event of a conversion error.
+    type Error;
+
+    /// Performs the conversion.
+    fn try_from(value: T) -> Result<Self, Self::Error>;
+}
+
+pub(crate) trait TryInto<T>: Sized {
+    /// The type returned in the event of a conversion error.
+    type Error;
+
+    /// Performs the conversion.
+    fn try_into(self) -> Result<T, Self::Error>;
+}
+
+// TryFrom implies TryInto
+impl<T, U> TryInto<U> for T where U: TryFrom<T>
+{
+    type Error = U::Error;
+
+    fn try_into(self) -> Result<U, U::Error> {
+        U::try_from(self)
+    }
+}
+
+pub(crate) struct TryFromIntError(());
+
+// no possible bounds violation
+macro_rules! try_from_unbounded {
+    ($source:ty, $($target:ty),*) => {$(
+        impl TryFrom<$source> for $target {
+            type Error = TryFromIntError;
+
+            /// Try to create the target number type from a source
+            /// number type. This returns an error if the source value
+            /// is outside of the range of the target type.
+            #[inline]
+            fn try_from(value: $source) -> Result<Self, Self::Error> {
+                Ok(value as $target)
+            }
+        }
+    )*}
+}
+
+// only negative bounds
+macro_rules! try_from_lower_bounded {
+    ($source:ty, $($target:ty),*) => {$(
+        impl TryFrom<$source> for $target {
+            type Error = TryFromIntError;
+
+            /// Try to create the target number type from a source
+            /// number type. This returns an error if the source value
+            /// is outside of the range of the target type.
+            #[inline]
+            fn try_from(u: $source) -> Result<$target, TryFromIntError> {
+                if u >= 0 {
+                    Ok(u as $target)
+                } else {
+                    Err(TryFromIntError(()))
+                }
+            }
+        }
+    )*}
+}
+
+// unsigned to signed (only positive bound)
+macro_rules! try_from_upper_bounded {
+    ($source:ty, $($target:ty),*) => {$(
+        impl TryFrom<$source> for $target {
+            type Error = TryFromIntError;
+
+            /// Try to create the target number type from a source
+            /// number type. This returns an error if the source value
+            /// is outside of the range of the target type.
+            #[inline]
+            fn try_from(u: $source) -> Result<$target, TryFromIntError> {
+                if u > (<$target>::max_value() as $source) {
+                    Err(TryFromIntError(()))
+                } else {
+                    Ok(u as $target)
+                }
+            }
+        }
+    )*}
+}
+
+// all other cases
+macro_rules! try_from_both_bounded {
+    ($source:ty, $($target:ty),*) => {$(
+        impl TryFrom<$source> for $target {
+            type Error = TryFromIntError;
+
+            /// Try to create the target number type from a source
+            /// number type. This returns an error if the source value
+            /// is outside of the range of the target type.
+            #[inline]
+            fn try_from(u: $source) -> Result<$target, TryFromIntError> {
+                let min = <$target>::min_value() as $source;
+                let max = <$target>::max_value() as $source;
+                if u < min || u > max {
+                    Err(TryFromIntError(()))
+                } else {
+                    Ok(u as $target)
+                }
+            }
+        }
+    )*}
+}
+
+macro_rules! rev {
+    ($mac:ident, $source:ty, $($target:ty),*) => {$(
+        $mac!($target, $source);
+    )*}
+}
+
+// intra-sign conversions
+try_from_upper_bounded!(u16, u8);
+try_from_upper_bounded!(u32, u16, u8);
+try_from_upper_bounded!(u64, u32, u16, u8);
+try_from_upper_bounded!(u128, u64, u32, u16, u8);
+
+try_from_both_bounded!(i16, i8);
+try_from_both_bounded!(i32, i16, i8);
+try_from_both_bounded!(i64, i32, i16, i8);
+try_from_both_bounded!(i128, i64, i32, i16, i8);
+
+// unsigned-to-signed
+try_from_upper_bounded!(u8, i8);
+try_from_upper_bounded!(u16, i8, i16);
+try_from_upper_bounded!(u32, i8, i16, i32);
+try_from_upper_bounded!(u64, i8, i16, i32, i64);
+try_from_upper_bounded!(u128, i8, i16, i32, i64, i128);
+
+// signed-to-unsigned
+try_from_lower_bounded!(i8, u8, u16, u32, u64, u128);
+try_from_lower_bounded!(i16, u16, u32, u64, u128);
+try_from_lower_bounded!(i32, u32, u64, u128);
+try_from_lower_bounded!(i64, u64, u128);
+try_from_lower_bounded!(i128, u128);
+try_from_both_bounded!(i16, u8);
+try_from_both_bounded!(i32, u16, u8);
+try_from_both_bounded!(i64, u32, u16, u8);
+try_from_both_bounded!(i128, u64, u32, u16, u8);
+
+// usize/isize
+try_from_upper_bounded!(usize, isize);
+try_from_lower_bounded!(isize, usize);
+
+#[cfg(target_pointer_width = "16")]
+mod ptr_try_from_impls {
+    use super::TryFromIntError;
+    use super::TryFrom;
+
+    try_from_upper_bounded!(usize, u8);
+    try_from_unbounded!(usize, u16, u32, u64, u128);
+    try_from_upper_bounded!(usize, i8, i16);
+    try_from_unbounded!(usize, i32, i64, i128);
+
+    try_from_both_bounded!(isize, u8);
+    try_from_lower_bounded!(isize, u16, u32, u64, u128);
+    try_from_both_bounded!(isize, i8);
+    try_from_unbounded!(isize, i16, i32, i64, i128);
+
+    rev!(try_from_upper_bounded, usize, u32, u64, u128);
+    rev!(try_from_lower_bounded, usize, i8, i16);
+    rev!(try_from_both_bounded, usize, i32, i64, i128);
+
+    rev!(try_from_upper_bounded, isize, u16, u32, u64, u128);
+    rev!(try_from_both_bounded, isize, i32, i64, i128);
+}
+
+#[cfg(target_pointer_width = "32")]
+mod ptr_try_from_impls {
+    use super::TryFromIntError;
+    use super::TryFrom;
+
+    try_from_upper_bounded!(usize, u8, u16);
+    try_from_unbounded!(usize, u32, u64, u128);
+    try_from_upper_bounded!(usize, i8, i16, i32);
+    try_from_unbounded!(usize, i64, i128);
+
+    try_from_both_bounded!(isize, u8, u16);
+    try_from_lower_bounded!(isize, u32, u64, u128);
+    try_from_both_bounded!(isize, i8, i16);
+    try_from_unbounded!(isize, i32, i64, i128);
+
+    rev!(try_from_unbounded, usize, u32);
+    rev!(try_from_upper_bounded, usize, u64, u128);
+    rev!(try_from_lower_bounded, usize, i8, i16, i32);
+    rev!(try_from_both_bounded, usize, i64, i128);
+
+    rev!(try_from_unbounded, isize, u16);
+    rev!(try_from_upper_bounded, isize, u32, u64, u128);
+    rev!(try_from_unbounded, isize, i32);
+    rev!(try_from_both_bounded, isize, i64, i128);
+}
+
+#[cfg(target_pointer_width = "64")]
+mod ptr_try_from_impls {
+    use super::TryFromIntError;
+    use super::TryFrom;
+
+    try_from_upper_bounded!(usize, u8, u16, u32);
+    try_from_unbounded!(usize, u64, u128);
+    try_from_upper_bounded!(usize, i8, i16, i32, i64);
+    try_from_unbounded!(usize, i128);
+
+    try_from_both_bounded!(isize, u8, u16, u32);
+    try_from_lower_bounded!(isize, u64, u128);
+    try_from_both_bounded!(isize, i8, i16, i32);
+    try_from_unbounded!(isize, i64, i128);
+
+    rev!(try_from_unbounded, usize, u32, u64);
+    rev!(try_from_upper_bounded, usize, u128);
+    rev!(try_from_lower_bounded, usize, i8, i16, i32, i64);
+    rev!(try_from_both_bounded, usize, i128);
+
+    rev!(try_from_unbounded, isize, u16, u32);
+    rev!(try_from_upper_bounded, isize, u64, u128);
+    rev!(try_from_unbounded, isize, i32, i64);
+    rev!(try_from_both_bounded, isize, i128);
+}

--- a/src/try_into.rs
+++ b/src/try_into.rs
@@ -120,30 +120,25 @@ macro_rules! rev {
 try_from_upper_bounded!(u16, u8);
 try_from_upper_bounded!(u32, u16, u8);
 try_from_upper_bounded!(u64, u32, u16, u8);
-try_from_upper_bounded!(u128, u64, u32, u16, u8);
 
 try_from_both_bounded!(i16, i8);
 try_from_both_bounded!(i32, i16, i8);
 try_from_both_bounded!(i64, i32, i16, i8);
-try_from_both_bounded!(i128, i64, i32, i16, i8);
 
 // unsigned-to-signed
 try_from_upper_bounded!(u8, i8);
 try_from_upper_bounded!(u16, i8, i16);
 try_from_upper_bounded!(u32, i8, i16, i32);
 try_from_upper_bounded!(u64, i8, i16, i32, i64);
-try_from_upper_bounded!(u128, i8, i16, i32, i64, i128);
 
 // signed-to-unsigned
-try_from_lower_bounded!(i8, u8, u16, u32, u64, u128);
-try_from_lower_bounded!(i16, u16, u32, u64, u128);
-try_from_lower_bounded!(i32, u32, u64, u128);
-try_from_lower_bounded!(i64, u64, u128);
-try_from_lower_bounded!(i128, u128);
+try_from_lower_bounded!(i8, u8, u16, u32, u64);
+try_from_lower_bounded!(i16, u16, u32, u64);
+try_from_lower_bounded!(i32, u32, u64);
+try_from_lower_bounded!(i64, u64);
 try_from_both_bounded!(i16, u8);
 try_from_both_bounded!(i32, u16, u8);
 try_from_both_bounded!(i64, u32, u16, u8);
-try_from_both_bounded!(i128, u64, u32, u16, u8);
 
 // usize/isize
 try_from_upper_bounded!(usize, isize);
@@ -155,21 +150,21 @@ mod ptr_try_from_impls {
     use super::TryFrom;
 
     try_from_upper_bounded!(usize, u8);
-    try_from_unbounded!(usize, u16, u32, u64, u128);
+    try_from_unbounded!(usize, u16, u32, u64);
     try_from_upper_bounded!(usize, i8, i16);
-    try_from_unbounded!(usize, i32, i64, i128);
+    try_from_unbounded!(usize, i32, i64);
 
     try_from_both_bounded!(isize, u8);
-    try_from_lower_bounded!(isize, u16, u32, u64, u128);
+    try_from_lower_bounded!(isize, u16, u32, u64);
     try_from_both_bounded!(isize, i8);
-    try_from_unbounded!(isize, i16, i32, i64, i128);
+    try_from_unbounded!(isize, i16, i32, i64);
 
-    rev!(try_from_upper_bounded, usize, u32, u64, u128);
+    rev!(try_from_upper_bounded, usize, u32, u64);
     rev!(try_from_lower_bounded, usize, i8, i16);
-    rev!(try_from_both_bounded, usize, i32, i64, i128);
+    rev!(try_from_both_bounded, usize, i32, i64);
 
-    rev!(try_from_upper_bounded, isize, u16, u32, u64, u128);
-    rev!(try_from_both_bounded, isize, i32, i64, i128);
+    rev!(try_from_upper_bounded, isize, u16, u32, u64);
+    rev!(try_from_both_bounded, isize, i32, i64);
 }
 
 #[cfg(target_pointer_width = "32")]
@@ -178,24 +173,24 @@ mod ptr_try_from_impls {
     use super::TryFrom;
 
     try_from_upper_bounded!(usize, u8, u16);
-    try_from_unbounded!(usize, u32, u64, u128);
+    try_from_unbounded!(usize, u32, u64);
     try_from_upper_bounded!(usize, i8, i16, i32);
-    try_from_unbounded!(usize, i64, i128);
+    try_from_unbounded!(usize, i64);
 
     try_from_both_bounded!(isize, u8, u16);
-    try_from_lower_bounded!(isize, u32, u64, u128);
+    try_from_lower_bounded!(isize, u32, u64);
     try_from_both_bounded!(isize, i8, i16);
-    try_from_unbounded!(isize, i32, i64, i128);
+    try_from_unbounded!(isize, i32, i64);
 
     rev!(try_from_unbounded, usize, u32);
-    rev!(try_from_upper_bounded, usize, u64, u128);
+    rev!(try_from_upper_bounded, usize, u64);
     rev!(try_from_lower_bounded, usize, i8, i16, i32);
-    rev!(try_from_both_bounded, usize, i64, i128);
+    rev!(try_from_both_bounded, usize, i64);
 
     rev!(try_from_unbounded, isize, u16);
-    rev!(try_from_upper_bounded, isize, u32, u64, u128);
+    rev!(try_from_upper_bounded, isize, u32, u64);
     rev!(try_from_unbounded, isize, i32);
-    rev!(try_from_both_bounded, isize, i64, i128);
+    rev!(try_from_both_bounded, isize, i64);
 }
 
 #[cfg(target_pointer_width = "64")]
@@ -204,22 +199,18 @@ mod ptr_try_from_impls {
     use super::TryFrom;
 
     try_from_upper_bounded!(usize, u8, u16, u32);
-    try_from_unbounded!(usize, u64, u128);
+    try_from_unbounded!(usize, u64);
     try_from_upper_bounded!(usize, i8, i16, i32, i64);
-    try_from_unbounded!(usize, i128);
 
     try_from_both_bounded!(isize, u8, u16, u32);
-    try_from_lower_bounded!(isize, u64, u128);
+    try_from_lower_bounded!(isize, u64);
     try_from_both_bounded!(isize, i8, i16, i32);
-    try_from_unbounded!(isize, i64, i128);
+    try_from_unbounded!(isize, i64);
 
     rev!(try_from_unbounded, usize, u32, u64);
-    rev!(try_from_upper_bounded, usize, u128);
     rev!(try_from_lower_bounded, usize, i8, i16, i32, i64);
-    rev!(try_from_both_bounded, usize, i128);
 
     rev!(try_from_unbounded, isize, u16, u32);
-    rev!(try_from_upper_bounded, isize, u64, u128);
+    rev!(try_from_upper_bounded, isize, u64);
     rev!(try_from_unbounded, isize, i32, i64);
-    rev!(try_from_both_bounded, isize, i128);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -469,6 +469,10 @@ fn test_oom_protection() {
         .limit(10)
         .deserialize_from(&mut Cursor::new(&x[..]));
     assert!(y.is_err());
+    let y: Result<String> = config()
+        .limit(10)
+        .deserialize_from(&mut Cursor::new(&x[..]));
+    assert!(y.is_err());
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,37 +13,10 @@ use std::result::Result as StdResult;
 
 use bincode::{
     config, deserialize, deserialize_from, deserialize_in_place, serialize, serialized_size,
-    ErrorKind, Result,
+    ErrorKind, Result, LengthOption,
 };
 use serde::de::{Deserialize, DeserializeSeed, Deserializer, SeqAccess, Visitor};
 
-fn the_same<V>(element: V)
-where
-    V: serde::Serialize + serde::de::DeserializeOwned + PartialEq + Debug + 'static,
-{
-    let size = serialized_size(&element).unwrap();
-
-    {
-        let encoded = serialize(&element).unwrap();
-        let decoded = deserialize(&encoded[..]).unwrap();
-
-        assert_eq!(element, decoded);
-        assert_eq!(size, encoded.len() as u64);
-    }
-
-    {
-        let encoded = config().big_endian().serialize(&element).unwrap();
-        let decoded = config().big_endian().deserialize(&encoded[..]).unwrap();
-        let decoded_reader = config()
-            .big_endian()
-            .deserialize_from(&mut &encoded[..])
-            .unwrap();
-
-        assert_eq!(element, decoded);
-        assert_eq!(element, decoded_reader);
-        assert_eq!(size, encoded.len() as u64);
-    }
-}
 #[test]
 fn test_numbers() {
     // unsigned positive
@@ -72,6 +45,76 @@ fn test_numbers() {
     the_same(5f64);
 }
 
+fn the_same<V>(element: V)
+    where
+        V: serde::Serialize + serde::de::DeserializeOwned + PartialEq + Debug + 'static,
+{
+    let size = serialized_size(&element).unwrap();
+
+    {
+        let encoded = serialize(&element).unwrap();
+        let decoded = deserialize(&encoded[..]).unwrap();
+
+        assert_eq!(element, decoded);
+        assert_eq!(size, encoded.len() as u64);
+    }
+
+    {
+        let encoded = config().big_endian().serialize(&element).unwrap();
+        let decoded = config().big_endian().deserialize(&encoded[..]).unwrap();
+        let decoded_reader = config()
+            .big_endian()
+            .deserialize_from(&mut &encoded[..])
+            .unwrap();
+
+        assert_eq!(element, decoded);
+        assert_eq!(element, decoded_reader);
+        assert_eq!(size, encoded.len() as u64);
+    }
+}
+
+fn the_same_str(element: String) {
+    let with_length = |length: LengthOption| {
+        let size = serialized_size(&element).unwrap();
+        let encoded = config().string_length(length).serialize(&element).unwrap();
+        let decoded: String = config().string_length(length).deserialize(&encoded[..]).unwrap();
+        let decoded_reader: String = config()
+            .string_length(length)
+            .deserialize_from(&mut &encoded[..])
+            .unwrap();
+
+        assert_eq!(element, decoded);
+        assert_eq!(element, decoded_reader);
+        assert_eq!(size, encoded.len() as u64);
+    };
+    with_length(LengthOption::U64);
+    with_length(LengthOption::U32);
+    with_length(LengthOption::U16);
+    with_length(LengthOption::U8);
+    the_same(element);
+}
+
+fn the_same_vec<T>(element: Vec<T>) where T: serde::Serialize + serde::de::DeserializeOwned + PartialEq + Debug + 'static {
+    let with_length = |length: LengthOption| {
+        let size = serialized_size(&element).unwrap();
+        let encoded = config().string_length(length).serialize(&element).unwrap();
+        let decoded: Vec<T> = config().string_length(length).deserialize(&encoded[..]).unwrap();
+        let decoded_reader: Vec<T> = config()
+            .string_length(length)
+            .deserialize_from(&mut &encoded[..])
+            .unwrap();
+
+        assert_eq!(element, decoded);
+        assert_eq!(element, decoded_reader);
+        assert_eq!(size, encoded.len() as u64);
+    };
+    with_length(LengthOption::U64);
+    with_length(LengthOption::U32);
+    with_length(LengthOption::U16);
+    with_length(LengthOption::U8);
+    the_same(element);
+}
+
 #[cfg(has_i128)]
 #[test]
 fn test_numbers_128bit() {
@@ -88,8 +131,8 @@ fn test_numbers_128bit() {
 
 #[test]
 fn test_string() {
-    the_same("".to_string());
-    the_same("a".to_string());
+    the_same_str("".to_string());
+    the_same_str("a".to_string());
 }
 
 #[test]
@@ -193,9 +236,9 @@ fn test_enum() {
 #[test]
 fn test_vec() {
     let v: Vec<u8> = vec![];
-    the_same(v);
-    the_same(vec![1u64]);
-    the_same(vec![1u64, 2, 3, 4, 5, 6]);
+    the_same_vec(v);
+    the_same_vec(vec![1u64]);
+    the_same_vec(vec![1u64, 2, 3, 4, 5, 6]);
 }
 
 #[test]
@@ -214,8 +257,8 @@ fn test_bool() {
 
 #[test]
 fn test_unicode() {
-    the_same("å".to_string());
-    the_same("aåååååååa".to_string());
+    the_same_str("å".to_string());
+    the_same_str("aåååååååa".to_string());
 }
 
 #[test]
@@ -417,7 +460,7 @@ fn test_oom_protection() {
         byte: u8,
     }
     let x = config()
-        .limit(10)
+                .limit(10)
         .serialize(&FakeVec {
             len: 0xffffffffffffffffu64,
             byte: 1,
@@ -715,4 +758,36 @@ fn test_big_endian_deserialize_from_seed() {
     }
 
     assert_eq!(seed_data, (0..100).collect::<Vec<_>>());
+}
+
+#[test]
+fn test_str_size() {
+    let str = "abcd";
+    the_same_str(str.to_owned());
+    let size = config().serialized_size(str).unwrap();
+    assert_eq!(12, size);
+    let size = config().string_length(LengthOption::U64).serialized_size(str).unwrap();
+    assert_eq!(12, size);
+    let size = config().string_length(LengthOption::U32).serialized_size(str).unwrap();
+    assert_eq!(8, size);
+    let size = config().string_length(LengthOption::U16).serialized_size(str).unwrap();
+    assert_eq!(6, size);
+    let size = config().string_length(LengthOption::U8).serialized_size(str).unwrap();
+    assert_eq!(5, size);
+}
+
+#[test]
+fn test_vec_size() {
+    let v = vec![1u32, 2, 3, 4];
+    the_same_vec(v.clone());
+    let size = config().serialized_size(&v).unwrap();
+    assert_eq!(16 + 8, size);
+    let size = config().string_length(LengthOption::U64).serialized_size(&v).unwrap();
+    assert_eq!(16 + 8, size);
+    let size = config().string_length(LengthOption::U32).serialized_size(&v).unwrap();
+    assert_eq!(16 + 4, size);
+    let size = config().string_length(LengthOption::U16).serialized_size(&v).unwrap();
+    assert_eq!(16 + 2, size);
+    let size = config().string_length(LengthOption::U8).serialized_size(&v).unwrap();
+    assert_eq!(16 + 1, size);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,7 +13,7 @@ use std::result::Result as StdResult;
 
 use bincode::{
     config, deserialize, deserialize_from, deserialize_in_place, serialize, serialized_size,
-    ErrorKind, Result, LengthOption,
+    ErrorKind, LengthOption, Result,
 };
 use serde::de::{Deserialize, DeserializeSeed, Deserializer, SeqAccess, Visitor};
 
@@ -46,8 +46,8 @@ fn test_numbers() {
 }
 
 fn the_same<V>(element: V)
-    where
-        V: serde::Serialize + serde::de::DeserializeOwned + PartialEq + Debug + 'static,
+where
+    V: serde::Serialize + serde::de::DeserializeOwned + PartialEq + Debug + 'static,
 {
     let size = serialized_size(&element).unwrap();
 
@@ -75,9 +75,15 @@ fn the_same<V>(element: V)
 
 fn the_same_str(element: String) {
     let with_length = |length: LengthOption| {
-        let size = config().string_length(length).serialized_size(&element).unwrap();
+        let size = config()
+            .string_length(length)
+            .serialized_size(&element)
+            .unwrap();
         let encoded = config().string_length(length).serialize(&element).unwrap();
-        let decoded: String = config().string_length(length).deserialize(&encoded[..]).unwrap();
+        let decoded: String = config()
+            .string_length(length)
+            .deserialize(&encoded[..])
+            .unwrap();
         let decoded_reader: String = config()
             .string_length(length)
             .deserialize_from(&mut &encoded[..])
@@ -94,11 +100,20 @@ fn the_same_str(element: String) {
     the_same(element);
 }
 
-fn the_same_vec<T>(element: Vec<T>) where T: serde::Serialize + serde::de::DeserializeOwned + PartialEq + Debug + 'static {
+fn the_same_vec<T>(element: Vec<T>)
+where
+    T: serde::Serialize + serde::de::DeserializeOwned + PartialEq + Debug + 'static,
+{
     let with_length = |length: LengthOption| {
-        let size = config().string_length(length).serialized_size(&element).unwrap();
+        let size = config()
+            .string_length(length)
+            .serialized_size(&element)
+            .unwrap();
         let encoded = config().string_length(length).serialize(&element).unwrap();
-        let decoded: Vec<T> = config().string_length(length).deserialize(&encoded[..]).unwrap();
+        let decoded: Vec<T> = config()
+            .string_length(length)
+            .deserialize(&encoded[..])
+            .unwrap();
         let decoded_reader: Vec<T> = config()
             .string_length(length)
             .deserialize_from(&mut &encoded[..])
@@ -375,12 +390,10 @@ fn test_serialized_size_bounded() {
     assert!(config().limit(7).serialized_size(&0u64).is_err());
     assert!(config().limit(7).serialized_size(&"").is_err());
     assert!(config().limit(8 + 0).serialized_size(&"a").is_err());
-    assert!(
-        config()
-            .limit(8 + 3 * 4 - 1)
-            .serialized_size(&vec![0u32, 1u32, 2u32])
-            .is_err()
-    );
+    assert!(config()
+        .limit(8 + 3 * 4 - 1)
+        .serialized_size(&vec![0u32, 1u32, 2u32])
+        .is_err());
 }
 
 #[test]
@@ -460,11 +473,12 @@ fn test_oom_protection() {
         byte: u8,
     }
     let x = config()
-                .limit(10)
+        .limit(10)
         .serialize(&FakeVec {
             len: 0xffffffffffffffffu64,
             byte: 1,
-        }).unwrap();
+        })
+        .unwrap();
     let y: Result<Vec<u8>> = config()
         .limit(10)
         .deserialize_from(&mut Cursor::new(&x[..]));
@@ -626,7 +640,8 @@ fn test_zero_copy_parse_deserialize_into() {
                 slice: &encoded[..],
             },
             &mut target,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(target, f);
     }
 }
@@ -772,20 +787,48 @@ fn test_str_size() {
     let actual = config().serialize(str).unwrap().len();
     assert_eq!(12, expected);
     assert_eq!(12, actual);
-    let expected = config().string_length(LengthOption::U64).serialized_size(str).unwrap();
-    let actual = config().string_length(LengthOption::U64).serialize(str).unwrap().len();
+    let expected = config()
+        .string_length(LengthOption::U64)
+        .serialized_size(str)
+        .unwrap();
+    let actual = config()
+        .string_length(LengthOption::U64)
+        .serialize(str)
+        .unwrap()
+        .len();
     assert_eq!(12, expected);
     assert_eq!(12, actual);
-    let expected = config().string_length(LengthOption::U32).serialized_size(str).unwrap();
-    let actual = config().string_length(LengthOption::U32).serialize(str).unwrap().len();
+    let expected = config()
+        .string_length(LengthOption::U32)
+        .serialized_size(str)
+        .unwrap();
+    let actual = config()
+        .string_length(LengthOption::U32)
+        .serialize(str)
+        .unwrap()
+        .len();
     assert_eq!(8, expected);
     assert_eq!(8, actual);
-    let expected = config().string_length(LengthOption::U16).serialized_size(str).unwrap();
-    let actual = config().string_length(LengthOption::U16).serialize(str).unwrap().len();
+    let expected = config()
+        .string_length(LengthOption::U16)
+        .serialized_size(str)
+        .unwrap();
+    let actual = config()
+        .string_length(LengthOption::U16)
+        .serialize(str)
+        .unwrap()
+        .len();
     assert_eq!(6, expected);
     assert_eq!(6, actual);
-    let expected = config().string_length(LengthOption::U8).serialized_size(str).unwrap();
-    let actual = config().string_length(LengthOption::U8).serialize(str).unwrap().len();
+    let expected = config()
+        .string_length(LengthOption::U8)
+        .serialized_size(str)
+        .unwrap();
+    let actual = config()
+        .string_length(LengthOption::U8)
+        .serialize(str)
+        .unwrap()
+        .len();
     assert_eq!(5, expected);
     assert_eq!(5, actual);
 }
@@ -798,20 +841,48 @@ fn test_vec_size() {
     let actual = config().serialize(&v).unwrap().len();
     assert_eq!(16 + 8, expected);
     assert_eq!(16 + 8, actual);
-    let expected = config().array_length(LengthOption::U64).serialized_size(&v).unwrap();
-    let actual = config().array_length(LengthOption::U64).serialize(&v).unwrap().len();
+    let expected = config()
+        .array_length(LengthOption::U64)
+        .serialized_size(&v)
+        .unwrap();
+    let actual = config()
+        .array_length(LengthOption::U64)
+        .serialize(&v)
+        .unwrap()
+        .len();
     assert_eq!(16 + 8, expected);
     assert_eq!(16 + 8, actual);
-    let expected = config().array_length(LengthOption::U32).serialized_size(&v).unwrap();
-    let actual = config().array_length(LengthOption::U32).serialize(&v).unwrap().len();
+    let expected = config()
+        .array_length(LengthOption::U32)
+        .serialized_size(&v)
+        .unwrap();
+    let actual = config()
+        .array_length(LengthOption::U32)
+        .serialize(&v)
+        .unwrap()
+        .len();
     assert_eq!(16 + 4, expected);
     assert_eq!(16 + 4, actual);
-    let expected = config().array_length(LengthOption::U16).serialized_size(&v).unwrap();
-    let actual = config().array_length(LengthOption::U16).serialize(&v).unwrap().len();
+    let expected = config()
+        .array_length(LengthOption::U16)
+        .serialized_size(&v)
+        .unwrap();
+    let actual = config()
+        .array_length(LengthOption::U16)
+        .serialize(&v)
+        .unwrap()
+        .len();
     assert_eq!(16 + 2, expected);
     assert_eq!(16 + 2, actual);
-    let expected = config().array_length(LengthOption::U8).serialized_size(&v).unwrap();
-    let actual = config().array_length(LengthOption::U8).serialize(&v).unwrap().len();
+    let expected = config()
+        .array_length(LengthOption::U8)
+        .serialized_size(&v)
+        .unwrap();
+    let actual = config()
+        .array_length(LengthOption::U8)
+        .serialize(&v)
+        .unwrap()
+        .len();
     assert_eq!(16 + 1, expected);
     assert_eq!(16 + 1, actual);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -75,7 +75,7 @@ fn the_same<V>(element: V)
 
 fn the_same_str(element: String) {
     let with_length = |length: LengthOption| {
-        let size = serialized_size(&element).unwrap();
+        let size = config().string_length(length).serialized_size(&element).unwrap();
         let encoded = config().string_length(length).serialize(&element).unwrap();
         let decoded: String = config().string_length(length).deserialize(&encoded[..]).unwrap();
         let decoded_reader: String = config()
@@ -96,7 +96,7 @@ fn the_same_str(element: String) {
 
 fn the_same_vec<T>(element: Vec<T>) where T: serde::Serialize + serde::de::DeserializeOwned + PartialEq + Debug + 'static {
     let with_length = |length: LengthOption| {
-        let size = serialized_size(&element).unwrap();
+        let size = config().string_length(length).serialized_size(&element).unwrap();
         let encoded = config().string_length(length).serialize(&element).unwrap();
         let decoded: Vec<T> = config().string_length(length).deserialize(&encoded[..]).unwrap();
         let decoded_reader: Vec<T> = config()
@@ -768,30 +768,50 @@ fn test_big_endian_deserialize_from_seed() {
 fn test_str_size() {
     let str = "abcd";
     the_same_str(str.to_owned());
-    let size = config().serialized_size(str).unwrap();
-    assert_eq!(12, size);
-    let size = config().string_length(LengthOption::U64).serialized_size(str).unwrap();
-    assert_eq!(12, size);
-    let size = config().string_length(LengthOption::U32).serialized_size(str).unwrap();
-    assert_eq!(8, size);
-    let size = config().string_length(LengthOption::U16).serialized_size(str).unwrap();
-    assert_eq!(6, size);
-    let size = config().string_length(LengthOption::U8).serialized_size(str).unwrap();
-    assert_eq!(5, size);
+    let expected = config().serialized_size(str).unwrap();
+    let actual = config().serialize(str).unwrap().len();
+    assert_eq!(12, expected);
+    assert_eq!(12, actual);
+    let expected = config().string_length(LengthOption::U64).serialized_size(str).unwrap();
+    let actual = config().string_length(LengthOption::U64).serialize(str).unwrap().len();
+    assert_eq!(12, expected);
+    assert_eq!(12, actual);
+    let expected = config().string_length(LengthOption::U32).serialized_size(str).unwrap();
+    let actual = config().string_length(LengthOption::U32).serialize(str).unwrap().len();
+    assert_eq!(8, expected);
+    assert_eq!(8, actual);
+    let expected = config().string_length(LengthOption::U16).serialized_size(str).unwrap();
+    let actual = config().string_length(LengthOption::U16).serialize(str).unwrap().len();
+    assert_eq!(6, expected);
+    assert_eq!(6, actual);
+    let expected = config().string_length(LengthOption::U8).serialized_size(str).unwrap();
+    let actual = config().string_length(LengthOption::U8).serialize(str).unwrap().len();
+    assert_eq!(5, expected);
+    assert_eq!(5, actual);
 }
 
 #[test]
 fn test_vec_size() {
     let v = vec![1u32, 2, 3, 4];
     the_same_vec(v.clone());
-    let size = config().serialized_size(&v).unwrap();
-    assert_eq!(16 + 8, size);
-    let size = config().string_length(LengthOption::U64).serialized_size(&v).unwrap();
-    assert_eq!(16 + 8, size);
-    let size = config().string_length(LengthOption::U32).serialized_size(&v).unwrap();
-    assert_eq!(16 + 4, size);
-    let size = config().string_length(LengthOption::U16).serialized_size(&v).unwrap();
-    assert_eq!(16 + 2, size);
-    let size = config().string_length(LengthOption::U8).serialized_size(&v).unwrap();
-    assert_eq!(16 + 1, size);
+    let expected = config().serialized_size(&v).unwrap();
+    let actual = config().serialize(&v).unwrap().len();
+    assert_eq!(16 + 8, expected);
+    assert_eq!(16 + 8, actual);
+    let expected = config().array_length(LengthOption::U64).serialized_size(&v).unwrap();
+    let actual = config().array_length(LengthOption::U64).serialize(&v).unwrap().len();
+    assert_eq!(16 + 8, expected);
+    assert_eq!(16 + 8, actual);
+    let expected = config().array_length(LengthOption::U32).serialized_size(&v).unwrap();
+    let actual = config().array_length(LengthOption::U32).serialize(&v).unwrap().len();
+    assert_eq!(16 + 4, expected);
+    assert_eq!(16 + 4, actual);
+    let expected = config().array_length(LengthOption::U16).serialized_size(&v).unwrap();
+    let actual = config().array_length(LengthOption::U16).serialize(&v).unwrap().len();
+    assert_eq!(16 + 2, expected);
+    assert_eq!(16 + 2, actual);
+    let expected = config().array_length(LengthOption::U8).serialized_size(&v).unwrap();
+    let actual = config().array_length(LengthOption::U8).serialize(&v).unwrap().len();
+    assert_eq!(16 + 1, expected);
+    assert_eq!(16 + 1, actual);
 }


### PR DESCRIPTION
This change adds two new config values `string_size` and `array_size`. 
Both of which take an enum to allow the lengths of strings and vectors/arrays to be set to:
`U8`, `U16`, `U32`, and `U64`. Where `U64` is the default. (Which is compatible with current behavior.)

In the event that the data being serialized does not fit into the size specified the serialization will fail with `ErrorKind::SizeTypeLimit`

Fixes #285 .