### PR TITLE
Fix compile warnings caused by deprecated macros.

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -48,7 +48,7 @@ impl<'de, R: BincodeRead<'de>, O: Options> Deserializer<R, O> {
     }
 
     fn read_vec(&mut self) -> Result<Vec<u8>> {
-        let len: usize = try!(serde::Deserialize::deserialize(&mut *self));
+        let len: usize = serde::Deserialize::deserialize(&mut *self)?;
         self.read_bytes(len as u64)?;
         self.reader.get_byte_buffer(len)
     }
@@ -65,8 +65,8 @@ macro_rules! impl_nums {
         fn $dser_method<V>(self, visitor: V) -> Result<V::Value>
             where V: serde::de::Visitor<'de>,
         {
-            try!(self.read_type::<$ty>());
-            let value = try!(self.reader.$reader_method::<O::Endian>());
+            self.read_type::<$ty>()?;
+            let value = self.reader.$reader_method::<O::Endian>()?;
             visitor.$visitor_method(value)
         }
     }
@@ -91,7 +91,7 @@ where
     where
         V: serde::de::Visitor<'de>,
     {
-        let value: u8 = try!(serde::Deserialize::deserialize(self));
+        let value: u8 = serde::Deserialize::deserialize(self)?;
         match value {
             1 => visitor.visit_bool(true),
             0 => visitor.visit_bool(false),
@@ -118,8 +118,8 @@ where
     where
         V: serde::de::Visitor<'de>,
     {
-        try!(self.read_type::<u8>());
-        visitor.visit_u8(try!(self.reader.read_u8()))
+        self.read_type::<u8>()?;
+        visitor.visit_u8(self.reader.read_u8()?)
     }
 
     #[inline]
@@ -127,8 +127,8 @@ where
     where
         V: serde::de::Visitor<'de>,
     {
-        try!(self.read_type::<i8>());
-        visitor.visit_i8(try!(self.reader.read_i8()))
+        self.read_type::<i8>()?;
+        visitor.visit_i8(self.reader.read_i8()?)
     }
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
@@ -149,7 +149,7 @@ where
         let mut buf = [0u8; 4];
 
         // Look at the first byte to see how many bytes must be read
-        let _ = try!(self.reader.read_exact(&mut buf[..1]));
+        let _ = self.reader.read_exact(&mut buf[..1])?;
         let width = utf8_char_width(buf[0]);
         if width == 1 {
             return visitor.visit_char(buf[0] as char);
@@ -162,12 +162,10 @@ where
             return Err(error());
         }
 
-        let res = try!(
-            str::from_utf8(&buf[..width])
+        let res = str::from_utf8(&buf[..width])
                 .ok()
                 .and_then(|s| s.chars().next())
-                .ok_or(error())
-        );
+                .ok_or(error())?;
         visitor.visit_char(res)
     }
 
@@ -175,8 +173,8 @@ where
     where
         V: serde::de::Visitor<'de>,
     {
-        let len: usize = try!(serde::Deserialize::deserialize(&mut *self));
-        try!(self.read_bytes(len as u64));
+        let len: usize = serde::Deserialize::deserialize(&mut *self)?;
+        self.read_bytes(len as u64)?;
         self.reader.forward_read_str(len, visitor)
     }
 
@@ -184,15 +182,15 @@ where
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_string(try!(self.read_string()))
+        visitor.visit_string(self.read_string()?)
     }
 
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
     where
         V: serde::de::Visitor<'de>,
     {
-        let len: usize = try!(serde::Deserialize::deserialize(&mut *self));
-        try!(self.read_bytes(len as u64));
+        let len: usize = serde::Deserialize::deserialize(&mut *self)?;
+        self.read_bytes(len as u64)?;
         self.reader.forward_read_bytes(len, visitor)
     }
 
@@ -200,7 +198,7 @@ where
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_byte_buf(try!(self.read_vec()))
+        visitor.visit_byte_buf(self.read_vec()?)
     }
 
     fn deserialize_enum<V>(
@@ -224,9 +222,9 @@ where
             where
                 V: serde::de::DeserializeSeed<'de>,
             {
-                let idx: u32 = try!(serde::de::Deserialize::deserialize(&mut *self));
+                let idx: u32 = serde::de::Deserialize::deserialize(&mut *self)?;
                 let val: Result<_> = seed.deserialize(idx.into_deserializer());
-                Ok((try!(val), self))
+                Ok((val?, self))
             }
         }
 
@@ -253,10 +251,10 @@ where
             {
                 if self.len > 0 {
                     self.len -= 1;
-                    let value = try!(serde::de::DeserializeSeed::deserialize(
+                    let value = serde::de::DeserializeSeed::deserialize(
                         seed,
                         &mut *self.deserializer,
-                    ));
+                    )?;
                     Ok(Some(value))
                 } else {
                     Ok(None)
@@ -278,7 +276,7 @@ where
     where
         V: serde::de::Visitor<'de>,
     {
-        let value: u8 = try!(serde::de::Deserialize::deserialize(&mut *self));
+        let value: u8 = serde::de::Deserialize::deserialize(&mut *self)?;
         match value {
             0 => visitor.visit_none(),
             1 => visitor.visit_some(&mut *self),
@@ -290,7 +288,7 @@ where
     where
         V: serde::de::Visitor<'de>,
     {
-        let len = try!(serde::Deserialize::deserialize(&mut *self));
+        let len = serde::Deserialize::deserialize(&mut *self)?;
 
         self.deserialize_tuple(len, visitor)
     }
@@ -315,10 +313,10 @@ where
             {
                 if self.len > 0 {
                     self.len -= 1;
-                    let key = try!(serde::de::DeserializeSeed::deserialize(
+                    let key = serde::de::DeserializeSeed::deserialize(
                         seed,
                         &mut *self.deserializer,
-                    ));
+                    )?;
                     Ok(Some(key))
                 } else {
                     Ok(None)
@@ -329,10 +327,10 @@ where
             where
                 V: serde::de::DeserializeSeed<'de>,
             {
-                let value = try!(serde::de::DeserializeSeed::deserialize(
+                let value = serde::de::DeserializeSeed::deserialize(
                     seed,
                     &mut *self.deserializer,
-                ));
+                )?;
                 Ok(value)
             }
 
@@ -341,7 +339,7 @@ where
             }
         }
 
-        let len = try!(serde::Deserialize::deserialize(&mut *self));
+        let len = serde::Deserialize::deserialize(&mut *self)?;
 
         visitor.visit_map(Access {
             deserializer: self,

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,7 +58,7 @@ impl StdError for ErrorKind {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             ErrorKind::Io(ref err) => Some(err),
             ErrorKind::InvalidUtf8Encoding(_) => None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,7 +58,7 @@ impl StdError for ErrorKind {
         }
     }
 
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn cause(&self) -> Option<&error::Error> {
         match *self {
             ErrorKind::Io(ref err) => Some(err),
             ErrorKind::InvalidUtf8Encoding(_) => None,

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -107,7 +107,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
-        try!(self.serialize_u64(v.len() as u64));
+        self.serialize_u64(v.len() as u64)?;
         self.writer.write_all(v.as_bytes()).map_err(Into::into)
     }
 
@@ -118,7 +118,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<()> {
-        try!(self.serialize_u64(v.len() as u64));
+        self.serialize_u64(v.len() as u64)?;
         self.writer.write_all(v).map_err(Into::into)
     }
 
@@ -130,13 +130,13 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     where
         T: serde::Serialize,
     {
-        try!(self.writer.write_u8(1));
+        self.writer.write_u8(1)?;
         v.serialize(self)
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
-        let len = try!(len.ok_or(ErrorKind::SequenceMustHaveLength));
-        try!(self.serialize_u64(len as u64));
+        let len = len.ok_or(ErrorKind::SequenceMustHaveLength)?;
+        self.serialize_u64(len as u64)?;
         Ok(Compound { ser: self })
     }
 
@@ -159,13 +159,13 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
-        try!(self.serialize_u32(variant_index));
+        self.serialize_u32(variant_index)?;
         Ok(Compound { ser: self })
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
-        let len = try!(len.ok_or(ErrorKind::SequenceMustHaveLength));
-        try!(self.serialize_u64(len as u64));
+        let len = len.ok_or(ErrorKind::SequenceMustHaveLength)?;
+        self.serialize_u64(len as u64)?;
         Ok(Compound { ser: self })
     }
 
@@ -180,7 +180,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        try!(self.serialize_u32(variant_index));
+        self.serialize_u32(variant_index)?;
         Ok(Compound { ser: self })
     }
 
@@ -201,7 +201,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     where
         T: serde::ser::Serialize,
     {
-        try!(self.serialize_u32(variant_index));
+        self.serialize_u32(variant_index)?;
         value.serialize(self)
     }
 
@@ -312,7 +312,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
-        try!(self.add_value(0 as u64));
+        self.add_value(0 as u64)?;
         self.add_raw(v.len() as u64)
     }
 
@@ -321,7 +321,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<()> {
-        try!(self.add_value(0 as u64));
+        self.add_value(0 as u64)?;
         self.add_raw(v.len() as u64)
     }
 
@@ -333,14 +333,14 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
     where
         T: serde::Serialize,
     {
-        try!(self.add_value(1 as u8));
+        self.add_value(1 as u8)?;
         v.serialize(self)
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
-        let len = try!(len.ok_or(ErrorKind::SequenceMustHaveLength));
+        let len = len.ok_or(ErrorKind::SequenceMustHaveLength)?;
 
-        try!(self.serialize_u64(len as u64));
+        self.serialize_u64(len as u64)?;
         Ok(SizeCompound { ser: self })
     }
 
@@ -363,14 +363,14 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
-        try!(self.add_value(variant_index));
+        self.add_value(variant_index)?;
         Ok(SizeCompound { ser: self })
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
-        let len = try!(len.ok_or(ErrorKind::SequenceMustHaveLength));
+        let len = len.ok_or(ErrorKind::SequenceMustHaveLength)?;
 
-        try!(self.serialize_u64(len as u64));
+        self.serialize_u64(len as u64)?;
         Ok(SizeCompound { ser: self })
     }
 
@@ -385,7 +385,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        try!(self.add_value(variant_index));
+        self.add_value(variant_index)?;
         Ok(SizeCompound { ser: self })
     }
 
@@ -413,7 +413,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
         _variant: &'static str,
         value: &V,
     ) -> Result<()> {
-        try!(self.add_value(variant_index));
+        self.add_value(variant_index)?;
         value.serialize(self)
     }
 


### PR DESCRIPTION
I was getting a bunch of warnings like this:
```
warning: use of deprecated item 'try': use the `?` operator instead
   --> bincode/src/ser/mod.rs:416:9
    |
416 |         try!(self.add_value(variant_index));
    |         ^^^
```
With the latest compiler `cargo 1.40.0 (bc8e4c8be 2019-11-22)`

This change tries to fix them.