### PR TITLE
Restore shipping tests re bug #290

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ rust:
     - beta
     - nightly
 
-script: cargo test
+script:
+  - cargo test
+  - cargo package
+  - cd target/package/bincode-* && cargo test
 
 matrix:
   include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bincode"
 version = "1.2.1" # remember to update html_root_url
 authors = ["Ty Overby <ty@pre-alpha.com>", "Francesco Mazzoli <f@mazzo.li>", "David Tolnay <dtolnay@gmail.com>", "Daniel Griffen"]
-exclude = ["logo.png", "tests/*", "examples/*", ".gitignore", ".travis.yml"]
+exclude = ["logo.png", "examples/*", ".gitignore", ".travis.yml"]
 
 publish =  true
 


### PR DESCRIPTION
Includes changes to travis to re-run the test suite inside a copy
of the prepared package.

Closes: https://github.com/servo/bincode/issues/290