### PR TITLE
Publish 2.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bincode"
-version = "1.2.1" # remember to update html_root_url
+version = "2.0.0" # remember to update html_root_url
 authors = ["Ty Overby <ty@pre-alpha.com>", "Francesco Mazzoli <f@mazzo.li>", "David Tolnay <dtolnay@gmail.com>", "Daniel Griffen"]
 exclude = ["logo.png", "examples/*", ".gitignore", ".travis.yml"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! Support for `i128` and `u128` is automatically enabled on Rust toolchains
 //! greater than or equal to `1.26.0` and disabled for targets which do not support it
 
-#![doc(html_root_url = "https://docs.rs/bincode/1.2.1")]
+#![doc(html_root_url = "https://docs.rs/bincode/2.0.0")]
 #![crate_name = "bincode"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]


### PR DESCRIPTION
Any new version that includes https://github.com/servo/bincode/commit/e30e91e3a7d24925f09fdbd96773245a72fd7537 has to be a major version bump. While on one hand it would be nice to batch a bunch of breaking changes together, that would require a maintainer that is paying attention to this crate and has hopes and dreams for it, and that is not a good description of bincode's current maintainers :)