### PR TITLE
Varint enum tags and lengths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,5 @@ serde_derive = "1.0.27"
 # major version is released.
 i128 = []
 
-# Enabling this feature will make bincode treat enum discriminants and
-# sequence lengths as varints instead of u32s.
-varint = []
-
 [badges]
 travis-ci = { repository = "servo/bincode" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,9 @@ serde_derive = "1.0.27"
 # major version is released.
 i128 = []
 
+# Enabling this feature will make bincode treat enum discriminants and
+# sequence lengths as varints instead of u32s.
+varint = []
+
 [badges]
 travis-ci = { repository = "servo/bincode" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -448,42 +448,33 @@ impl IntEncoding for FixintEncoding {
     }
 
     #[inline(always)]
-    fn serialize_u16<W: Write, O: Options>(
-        ser: &mut crate::Serializer<W, O>,
-        val: u16,
-    ) -> Result<()> {
+    fn serialize_u16<W: Write, O: Options>(ser: &mut ::Serializer<W, O>, val: u16) -> Result<()> {
         ser.serialize_literal_u16(val)
     }
     #[inline(always)]
-    fn serialize_u32<W: Write, O: Options>(
-        ser: &mut crate::Serializer<W, O>,
-        val: u32,
-    ) -> Result<()> {
+    fn serialize_u32<W: Write, O: Options>(ser: &mut ::Serializer<W, O>, val: u32) -> Result<()> {
         ser.serialize_literal_u32(val)
     }
     #[inline(always)]
-    fn serialize_u64<W: Write, O: Options>(
-        ser: &mut crate::Serializer<W, O>,
-        val: u64,
-    ) -> Result<()> {
+    fn serialize_u64<W: Write, O: Options>(ser: &mut ::Serializer<W, O>, val: u64) -> Result<()> {
         ser.serialize_literal_u64(val)
     }
 
     #[inline(always)]
     fn deserialize_u16<'de, R: BincodeRead<'de>, O: Options>(
-        de: &mut crate::Deserializer<R, O>,
+        de: &mut ::Deserializer<R, O>,
     ) -> Result<u16> {
         de.deserialize_literal_u16()
     }
     #[inline(always)]
     fn deserialize_u32<'de, R: BincodeRead<'de>, O: Options>(
-        de: &mut crate::Deserializer<R, O>,
+        de: &mut ::Deserializer<R, O>,
     ) -> Result<u32> {
         de.deserialize_literal_u32()
     }
     #[inline(always)]
     fn deserialize_u64<'de, R: BincodeRead<'de>, O: Options>(
-        de: &mut crate::Deserializer<R, O>,
+        de: &mut ::Deserializer<R, O>,
     ) -> Result<u64> {
         de.deserialize_literal_u64()
     }
@@ -495,14 +486,14 @@ impl IntEncoding for FixintEncoding {
         }
     #[inline(always)]
         fn serialize_u128<W: Write, O: Options>(
-            ser: &mut crate::Serializer<W, O>,
+            ser: &mut ::Serializer<W, O>,
             val: u128,
         ) -> Result<()> {
             ser.serialize_literal_u128(val)
         }
     #[inline(always)]
         fn deserialize_u128<'de, R: BincodeRead<'de>, O: Options>(
-            de: &mut crate::Deserializer<R, O>,
+            de: &mut ::Deserializer<R, O>,
         ) -> Result<u128> {
             de.deserialize_literal_u128()
         }
@@ -524,42 +515,33 @@ impl IntEncoding for VarintEncoding {
     }
 
     #[inline(always)]
-    fn serialize_u16<W: Write, O: Options>(
-        ser: &mut crate::Serializer<W, O>,
-        val: u16,
-    ) -> Result<()> {
+    fn serialize_u16<W: Write, O: Options>(ser: &mut ::Serializer<W, O>, val: u16) -> Result<()> {
         Self::serialize_varint(ser, val as u64)
     }
     #[inline(always)]
-    fn serialize_u32<W: Write, O: Options>(
-        ser: &mut crate::Serializer<W, O>,
-        val: u32,
-    ) -> Result<()> {
+    fn serialize_u32<W: Write, O: Options>(ser: &mut ::Serializer<W, O>, val: u32) -> Result<()> {
         Self::serialize_varint(ser, val as u64)
     }
     #[inline(always)]
-    fn serialize_u64<W: Write, O: Options>(
-        ser: &mut crate::Serializer<W, O>,
-        val: u64,
-    ) -> Result<()> {
+    fn serialize_u64<W: Write, O: Options>(ser: &mut ::Serializer<W, O>, val: u64) -> Result<()> {
         Self::serialize_varint(ser, val)
     }
 
     #[inline(always)]
     fn deserialize_u16<'de, R: BincodeRead<'de>, O: Options>(
-        de: &mut crate::Deserializer<R, O>,
+        de: &mut ::Deserializer<R, O>,
     ) -> Result<u16> {
         Self::deserialize_varint(de).and_then(cast_u64_to_u16)
     }
     #[inline(always)]
     fn deserialize_u32<'de, R: BincodeRead<'de>, O: Options>(
-        de: &mut crate::Deserializer<R, O>,
+        de: &mut ::Deserializer<R, O>,
     ) -> Result<u32> {
         Self::deserialize_varint(de).and_then(cast_u64_to_u32)
     }
     #[inline(always)]
     fn deserialize_u64<'de, R: BincodeRead<'de>, O: Options>(
-        de: &mut crate::Deserializer<R, O>,
+        de: &mut ::Deserializer<R, O>,
     ) -> Result<u64> {
         Self::deserialize_varint(de)
     }
@@ -571,14 +553,14 @@ impl IntEncoding for VarintEncoding {
         }
         #[inline(always)]
         fn serialize_u128<W: Write, O: Options>(
-            ser: &mut crate::Serializer<W, O>,
+            ser: &mut ::Serializer<W, O>,
             val: u128,
         ) -> Result<()> {
             Self::serialize_varint128(ser, val)
         }
         #[inline(always)]
         fn deserialize_u128<'de, R: BincodeRead<'de>, O: Options>(
-            de: &mut crate::Deserializer<R, O>,
+            de: &mut ::Deserializer<R, O>,
         ) -> Result<u128> {
             Self::deserialize_varint128(de)
         }
@@ -982,11 +964,11 @@ mod internal {
         serde_if_integer128! {
             fn u128_size(v: u128) -> u64;
             fn serialize_u128<W: Write, O: Options>(
-                ser: &mut crate::Serializer<W, O>,
+                ser: &mut ::Serializer<W, O>,
                 val: u128,
             ) -> Result<()>;
             fn deserialize_u128<'de, R: BincodeRead<'de>, O: Options>(
-                de: &mut crate::Deserializer<R, O>,
+                de: &mut ::Deserializer<R, O>,
             ) -> Result<u128>;
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -317,7 +317,7 @@ impl VarintLength {
     ) -> Result<u64> {
         use serde::Deserialize;
 
-        const EXTENSION_POINT_ERR: &'static str = r#"
+        const EXTENSION_POINT_ERR: &str = r#"
         Bytes 254 and 255 are treated as extension points; they should not be encoding anything.
         Do you have a mismatched bincode version?
         "#;
@@ -517,7 +517,7 @@ impl<O: Options, L: LengthEncoding> WithOtherLength<O, L> {
     #[inline(always)]
     pub(crate) fn new(options: O) -> WithOtherLength<O, L> {
         WithOtherLength {
-            options: options,
+            options,
             _length: PhantomData,
         }
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -77,13 +77,14 @@ macro_rules! impl_nums {
     ($ty:ty, $dser_method:ident, $visitor_method:ident, $reader_method:ident) => {
         #[inline]
         fn $dser_method<V>(self, visitor: V) -> Result<V::Value>
-            where V: serde::de::Visitor<'de>,
+        where
+            V: serde::de::Visitor<'de>,
         {
             self.read_type::<$ty>()?;
             let value = self.reader.$reader_method::<<O::Endian as BincodeByteOrder>::Endian>()?;
             visitor.$visitor_method(value)
         }
-    }
+    };
 }
 
 impl<'de, 'a, R, O> serde::Deserializer<'de> for &'a mut Deserializer<R, O>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 
 use self::read::{BincodeRead, IoReader, SliceReader};
 use byteorder::ReadBytesExt;
-use config::{SizeLimit, LengthEncoding};
+use config::{LengthEncoding, SizeLimit};
 use serde;
 use serde::de::Error as DeError;
 use serde::de::IntoDeserializer;

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -96,16 +96,17 @@ impl<'de, R: BincodeRead<'de>, O: Options> Deserializer<R, O> {
     }
 
     fn deserialize_varint(&mut self) -> Result<usize> {
-        let mut byte: u8 = try!(serde::Deserialize::deserialize(&mut *self));
         let mut n = 0;
+        let mut shift = 0;
+        let mut byte: u8 = try!(serde::Deserialize::deserialize(&mut *self));
 
         while byte > 127 {
-            n |= (byte & 127) as usize;
+            n |= ((byte & 127) as usize) << shift;
+            shift += 7;
             byte = try!(serde::Deserialize::deserialize(&mut *self));
-            n <<= 7;
         }
 
-        Ok(n | byte as usize)
+        Ok(n | ((byte as usize) << shift))
     }
 }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -96,11 +96,18 @@ impl<'de, R: BincodeRead<'de>, O: Options> Deserializer<R, O> {
     }
 
     fn deserialize_varint(&mut self) -> Result<usize> {
+        use std::mem::size_of;
+
         let mut n = 0;
         let mut shift = 0;
         let mut byte: u8 = try!(serde::Deserialize::deserialize(&mut *self));
 
-        while byte > 127 {
+        // Only allow reading size_of + 1 bytes to avoid overflows on bitshifts
+        for _ in 0..(size_of::<usize>()) {
+            if byte < 128 {
+                break;
+            }
+
             n |= ((byte & 127) as usize) << shift;
             shift += 7;
             byte = try!(serde::Deserialize::deserialize(&mut *self));

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -8,6 +8,7 @@ use byteorder::WriteBytesExt;
 use super::config::{IntEncoding, SizeLimit};
 use super::{Error, ErrorKind, Result};
 use config::{BincodeByteOrder, Options};
+use std::mem::size_of;
 
 /// An Serializer that encodes values directly into a Writer.
 ///
@@ -28,7 +29,7 @@ macro_rules! impl_serialize_literal {
                 .$write::<<O::Endian as BincodeByteOrder>::Endian>(v)
                 .map_err(Into::into)
         }
-    }
+    };
 }
 
 impl<W: Write, O: Options> Serializer<W, O> {
@@ -58,7 +59,7 @@ macro_rules! impl_serialize_int {
         fn $ser_method(self, v: $ty) -> Result<()> {
             O::IntEncoding::$ser_int(self, v as $unsigned_ty)
         }
-    }
+    };
 }
 
 impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
@@ -320,11 +321,11 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
     }
 
     fn serialize_f32(self, _: f32) -> Result<()> {
-        self.add_raw(std::mem::size_of::<f32>() as u64)
+        self.add_raw(size_of::<f32>() as u64)
     }
 
     fn serialize_f64(self, _: f64) -> Result<()> {
-        self.add_raw(std::mem::size_of::<f64>() as u64)
+        self.add_raw(size_of::<f64>() as u64)
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -5,7 +5,7 @@ use serde;
 
 use byteorder::WriteBytesExt;
 
-use super::config::{SizeLimit, LengthEncoding};
+use super::config::{LengthEncoding, SizeLimit};
 use super::{Error, ErrorKind, Result};
 use config::{BincodeByteOrder, Options};
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -31,6 +31,43 @@ impl<W: Write, O: Options> Serializer<W, O> {
     }
 }
 
+#[cfg(not(feature = "varint"))]
+impl<W: Write, O: Options> Serializer<W, O> {
+    fn serialize_discriminant(&mut self, idx: u32) -> Result<()> {
+        use serde::Serialize;
+
+        idx.serialize(self)
+    }
+
+    fn serialize_len(&mut self, len: usize) -> Result<()> {
+        use serde::Serialize;
+
+        (len as u64).serialize(self)
+    }
+}
+
+#[cfg(feature = "varint")]
+impl<W: Write, O: Options> Serializer<W, O> {
+    fn serialize_discriminant(&mut self, idx: u32) -> Result<()> {
+        self.serialize_varint(idx as usize)
+    }
+
+    fn serialize_len(&mut self, len: usize) -> Result<()> {
+        self.serialize_varint(len)
+    }
+
+    fn serialize_varint(&mut self, mut n: usize) -> Result<()> {
+        use serde::Serialize;
+
+        while n > 127 {
+            try!((128 | n as u8).serialize(&mut *self));
+            n >>= 7;
+        }
+
+        (n as u8).serialize(&mut *self)
+    }
+}
+
 impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     type Ok = ();
     type Error = Error;
@@ -123,7 +160,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
-        self.serialize_u64(v.len() as u64)?;
+        self.serialize_len(v.len())?;
         self.writer.write_all(v.as_bytes()).map_err(Into::into)
     }
 
@@ -134,7 +171,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<()> {
-        self.serialize_u64(v.len() as u64)?;
+        self.serialize_len(v.len())?;
         self.writer.write_all(v).map_err(Into::into)
     }
 
@@ -152,7 +189,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
         let len = len.ok_or(ErrorKind::SequenceMustHaveLength)?;
-        self.serialize_u64(len as u64)?;
+        self.serialize_len(len)?;
         Ok(Compound { ser: self })
     }
 
@@ -175,13 +212,13 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
-        self.serialize_u32(variant_index)?;
+        self.serialize_discriminant(variant_index)?;
         Ok(Compound { ser: self })
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
         let len = len.ok_or(ErrorKind::SequenceMustHaveLength)?;
-        self.serialize_u64(len as u64)?;
+        self.serialize_len(len)?;
         Ok(Compound { ser: self })
     }
 
@@ -196,7 +233,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        self.serialize_u32(variant_index)?;
+        self.serialize_discriminant(variant_index)?;
         Ok(Compound { ser: self })
     }
 
@@ -217,7 +254,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     where
         T: serde::ser::Serialize,
     {
-        self.serialize_u32(variant_index)?;
+        self.serialize_discriminant(variant_index)?;
         value.serialize(self)
     }
 
@@ -227,7 +264,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
         variant_index: u32,
         _variant: &'static str,
     ) -> Result<()> {
-        self.serialize_u32(variant_index)
+        self.serialize_discriminant(variant_index)
     }
 
     fn is_human_readable(&self) -> bool {
@@ -251,6 +288,35 @@ impl<O: Options> SizeChecker<O> {
     fn add_value<T>(&mut self, t: T) -> Result<()> {
         use std::mem::size_of_val;
         self.add_raw(size_of_val(&t) as u64)
+    }
+}
+
+#[cfg(not(feature = "varint"))]
+impl<O: Options> SizeChecker<O> {
+    fn add_discriminant(&mut self, idx: u32) -> Result<()> {
+        self.add_value(idx)
+    }
+
+    fn add_len(&mut self, _: usize) -> Result<()> {
+        self.add_value(0 as u64)
+    }
+}
+
+#[cfg(feature = "varint")]
+impl<O: Options> SizeChecker<O> {
+    fn add_discriminant(&mut self, idx: u32) -> Result<()> {
+        self.add_varint(idx as usize)
+    }
+
+    fn add_len(&mut self, len: usize) -> Result<()> {
+        self.add_varint(len)
+    }
+
+    fn add_varint(&mut self, int: usize) -> Result<()> {
+        use std::mem::size_of;
+        let bits = size_of::<usize>() * 8 - int.leading_zeros() as usize;
+
+        self.add_raw(((bits.saturating_sub(1) / 7) + 1) as u64)
     }
 }
 
@@ -328,7 +394,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
-        self.add_value(0 as u64)?;
+        self.add_len(v.len())?;
         self.add_raw(v.len() as u64)
     }
 
@@ -337,7 +403,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<()> {
-        self.add_value(0 as u64)?;
+        self.add_len(v.len())?;
         self.add_raw(v.len() as u64)
     }
 
@@ -356,7 +422,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
         let len = len.ok_or(ErrorKind::SequenceMustHaveLength)?;
 
-        self.serialize_u64(len as u64)?;
+        self.add_len(len)?;
         Ok(SizeCompound { ser: self })
     }
 
@@ -386,7 +452,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
         let len = len.ok_or(ErrorKind::SequenceMustHaveLength)?;
 
-        self.serialize_u64(len as u64)?;
+        self.add_len(len)?;
         Ok(SizeCompound { ser: self })
     }
 
@@ -401,7 +467,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        self.add_value(variant_index)?;
+        self.add_discriminant(variant_index)?;
         Ok(SizeCompound { ser: self })
     }
 
@@ -419,7 +485,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
         variant_index: u32,
         _variant: &'static str,
     ) -> Result<()> {
-        self.add_value(variant_index)
+        self.add_discriminant(variant_index)
     }
 
     fn serialize_newtype_variant<V: serde::Serialize + ?Sized>(
@@ -429,7 +495,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
         _variant: &'static str,
         value: &V,
     ) -> Result<()> {
-        self.add_value(variant_index)?;
+        self.add_discriminant(variant_index)?;
         value.serialize(self)
     }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -312,11 +312,15 @@ impl<O: Options> SizeChecker<O> {
         self.add_varint(len)
     }
 
-    fn add_varint(&mut self, int: usize) -> Result<()> {
-        use std::mem::size_of;
-        let bits = size_of::<usize>() * 8 - int.leading_zeros() as usize;
+    fn add_varint(&mut self, mut n: usize) -> Result<()> {
+        let mut bytes = 1;
 
-        self.add_raw(((bits.saturating_sub(1) / 7) + 1) as u64)
+        while n > 127 {
+            n >>= 7;
+            bytes += 1;
+        }
+
+        self.add_raw(bytes)
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -846,8 +846,18 @@ fn test_big_endian_deserialize_from_seed() {
 #[cfg(feature = "varint")]
 #[test]
 fn test_varint_length_prefixes() {
-    assert_eq!(serialized_size(&vec![0u8; 127][..]).unwrap(), 1 + 127); // 2 ** 7 - 1
-    assert_eq!(serialized_size(&vec![0u8; 128][..]).unwrap(), 2 + 128); // 2 ** 7
-    assert_eq!(serialized_size(&vec![0u8; 16383][..]).unwrap(), 2 + 16383); // 2 ** 14 - 1
-    assert_eq!(serialized_size(&vec![0u8; 16384][..]).unwrap(), 3 + 16384); // 2 ** 14
+    let a = vec![0u8; 127]; // 2 ** 7 - 1
+    let b = vec![0u8; 128]; // 2 ** 7
+    let c = vec![0u8; 16383]; // 2 ** 14 - 1
+    let d = vec![0u8; 16384]; // 2 ** 14
+
+    assert_eq!(serialized_size(&a[..]).unwrap(), 1 + 127); // 2 ** 7 - 1
+    assert_eq!(serialized_size(&b[..]).unwrap(), 2 + 128); // 2 ** 7
+    assert_eq!(serialized_size(&c[..]).unwrap(), 2 + 16383); // 2 ** 14 - 1
+    assert_eq!(serialized_size(&d[..]).unwrap(), 3 + 16384); // 2 ** 14
+
+    the_same(a);
+    the_same(b);
+    the_same(c);
+    the_same(d);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -422,38 +422,6 @@ fn test_serialized_size_bounded() {
         .is_err());
 }
 
-#[cfg(feature = "varint")]
-#[test]
-fn test_serialized_size_bounded() {
-    // JUST RIGHT
-    assert!(config().limit(1).serialized_size(&0u8).unwrap() == 1);
-    assert!(config().limit(2).serialized_size(&0u16).unwrap() == 2);
-    assert!(config().limit(4).serialized_size(&0u32).unwrap() == 4);
-    assert!(config().limit(8).serialized_size(&0u64).unwrap() == 8);
-    assert!(config().limit(1).serialized_size(&"").unwrap() == 1);
-    assert!(config().limit(1 + 1).serialized_size(&"a").unwrap() == 1 + 1);
-    assert!(
-        config()
-            .limit(1 + 3 * 4)
-            .serialized_size(&vec![0u32, 1u32, 2u32])
-            .unwrap()
-            == 1 + 3 * 4
-    );
-    // Below
-    assert!(config().limit(0).serialized_size(&0u8).is_err());
-    assert!(config().limit(1).serialized_size(&0u16).is_err());
-    assert!(config().limit(3).serialized_size(&0u32).is_err());
-    assert!(config().limit(7).serialized_size(&0u64).is_err());
-    assert!(config().limit(0).serialized_size(&"").is_err());
-    assert!(config().limit(1 + 0).serialized_size(&"a").is_err());
-    assert!(
-        config()
-            .limit(1 + 3 * 4 - 1)
-            .serialized_size(&vec![0u32, 1u32, 2u32])
-            .is_err()
-    );
-}
-
 #[test]
 fn encode_box() {
     the_same(Box::new(5));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -233,6 +233,7 @@ fn test_fixed_size_array() {
     the_same([0u8; 19]);
 }
 
+#[cfg(not(feature = "varint"))]
 #[test]
 fn deserializing_errors() {
     match *deserialize::<bool>(&vec![0xA][..]).unwrap_err() {
@@ -252,6 +253,37 @@ fn deserializing_errors() {
     };
 
     match *deserialize::<Test>(&vec![0, 0, 0, 5][..]).unwrap_err() {
+        // Error message comes from serde
+        ErrorKind::Custom(_) => {}
+        _ => panic!(),
+    }
+    match *deserialize::<Option<u8>>(&vec![5, 0][..]).unwrap_err() {
+        ErrorKind::InvalidTagEncoding(_) => {}
+        _ => panic!(),
+    }
+}
+
+
+#[cfg(feature = "varint")]
+#[test]
+fn deserializing_errors() {
+    match *deserialize::<bool>(&vec![0xA][..]).unwrap_err() {
+        ErrorKind::InvalidBoolEncoding(0xA) => {}
+        _ => panic!(),
+    }
+    match *deserialize::<String>(&vec![1, 0xFF][..]).unwrap_err() {
+        ErrorKind::InvalidUtf8Encoding(_) => {}
+        _ => panic!(),
+    }
+
+    // Out-of-bounds variant
+    #[derive(Serialize, Deserialize, Debug)]
+    enum Test {
+        One,
+        Two,
+    };
+
+    match *deserialize::<Test>(&vec![5][..]).unwrap_err() {
         // Error message comes from serde
         ErrorKind::Custom(_) => {}
         _ => panic!(),
@@ -300,6 +332,7 @@ fn too_big_char_deserialize() {
     assert_eq!(deserialized.unwrap(), 'A');
 }
 
+#[cfg(not(feature = "varint"))]
 #[test]
 fn too_big_serialize() {
     assert!(DefaultOptions::new()
@@ -318,6 +351,17 @@ fn too_big_serialize() {
         .is_ok());
 }
 
+#[cfg(feature = "varint")]
+#[test]
+fn too_big_serialize() {
+    assert!(config().limit(3).serialize(&0u32).is_err());
+    assert!(config().limit(4).serialize(&0u32).is_ok());
+
+    assert!(config().limit(1 + 4).serialize(&"abcde").is_err());
+    assert!(config().limit(1 + 5).serialize(&"abcde").is_ok());
+}
+
+#[cfg(not(feature = "varint"))]
 #[test]
 fn test_serialized_size() {
     assert!(serialized_size(&0u8).unwrap() == 1);
@@ -332,6 +376,22 @@ fn test_serialized_size() {
     assert!(serialized_size(&vec![0u32, 1u32, 2u32]).unwrap() == 8 + 3 * (4));
 }
 
+#[cfg(feature = "varint")]
+#[test]
+fn test_serialized_size() {
+    assert!(serialized_size(&0u8).unwrap() == 1);
+    assert!(serialized_size(&0u16).unwrap() == 2);
+    assert!(serialized_size(&0u32).unwrap() == 4);
+    assert!(serialized_size(&0u64).unwrap() == 8);
+
+    // length isize stored as varint
+    assert!(serialized_size(&"").unwrap() == 1);
+    assert!(serialized_size(&"a").unwrap() == 1 + 1);
+
+    assert!(serialized_size(&vec![0u32, 1u32, 2u32]).unwrap() == 1 + 3 * (4));
+}
+
+#[cfg(not(feature = "varint"))]
 #[test]
 fn test_serialized_size_bounded() {
     // JUST RIGHT
@@ -413,6 +473,38 @@ fn test_serialized_size_bounded() {
         .with_limit(8 + 3 * 4 - 1)
         .serialized_size(&vec![0u32, 1u32, 2u32])
         .is_err());
+}
+
+#[cfg(feature = "varint")]
+#[test]
+fn test_serialized_size_bounded() {
+    // JUST RIGHT
+    assert!(config().limit(1).serialized_size(&0u8).unwrap() == 1);
+    assert!(config().limit(2).serialized_size(&0u16).unwrap() == 2);
+    assert!(config().limit(4).serialized_size(&0u32).unwrap() == 4);
+    assert!(config().limit(8).serialized_size(&0u64).unwrap() == 8);
+    assert!(config().limit(1).serialized_size(&"").unwrap() == 1);
+    assert!(config().limit(1 + 1).serialized_size(&"a").unwrap() == 1 + 1);
+    assert!(
+        config()
+            .limit(1 + 3 * 4)
+            .serialized_size(&vec![0u32, 1u32, 2u32])
+            .unwrap()
+            == 1 + 3 * 4
+    );
+    // Below
+    assert!(config().limit(0).serialized_size(&0u8).is_err());
+    assert!(config().limit(1).serialized_size(&0u16).is_err());
+    assert!(config().limit(3).serialized_size(&0u32).is_err());
+    assert!(config().limit(7).serialized_size(&0u64).is_err());
+    assert!(config().limit(0).serialized_size(&"").is_err());
+    assert!(config().limit(1 + 0).serialized_size(&"a").is_err());
+    assert!(
+        config()
+            .limit(1 + 3 * 4 - 1)
+            .serialized_size(&vec![0u32, 1u32, 2u32])
+            .is_err()
+    );
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -804,13 +804,25 @@ fn test_big_endian_deserialize_from_seed() {
 
 #[test]
 fn test_varint_length_prefixes() {
-    let a = vec![0u8; 127]; // 2 ** 7 - 1
-    let b = vec![0u8; 128]; // 2 ** 7
-    let c = vec![0u8; 16383]; // 2 ** 14 - 1
-    let d = vec![0u8; 16384]; // 2 ** 14
+    let a = vec![(); 127]; // should be a single byte
+    let b = vec![(); 250]; // also should be a single byte
+    let c = vec![(); 251];
+    let d = vec![(); u16::max_value() as usize + 1];
 
-    assert_eq!(DefaultOptions::new().with_varint_length().serialized_size(&a[..]).unwrap(), 1 + 127); // 2 ** 7 - 1
-    assert_eq!(DefaultOptions::new().with_varint_length().serialized_size(&b[..]).unwrap(), 2 + 128); // 2 ** 7
-    assert_eq!(DefaultOptions::new().with_varint_length().serialized_size(&c[..]).unwrap(), 2 + 16383); // 2 ** 14 - 1
-    assert_eq!(DefaultOptions::new().with_varint_length().serialized_size(&d[..]).unwrap(), 3 + 16384); // 2 ** 14
+    assert_eq!(
+        DefaultOptions::new().with_varint_length().serialized_size(&a[..]).unwrap(),
+        1
+    ); // 2 ** 7 - 1
+    assert_eq!(
+        DefaultOptions::new().with_varint_length().serialized_size(&b[..]).unwrap(),
+        1
+    ); // 250
+    assert_eq!(
+        DefaultOptions::new().with_varint_length().serialized_size(&c[..]).unwrap(),
+        (1 + std::mem::size_of::<u16>()) as u64
+    ); // 251
+    assert_eq!(
+        DefaultOptions::new().with_varint_length().serialized_size(&d[..]).unwrap(),
+        (1 + std::mem::size_of::<u32>()) as u64
+    ); // 2 ** 16 + 1
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -810,19 +810,31 @@ fn test_varint_length_prefixes() {
     let d = vec![(); u16::max_value() as usize + 1];
 
     assert_eq!(
-        DefaultOptions::new().with_varint_length().serialized_size(&a[..]).unwrap(),
+        DefaultOptions::new()
+            .with_varint_length()
+            .serialized_size(&a[..])
+            .unwrap(),
         1
     ); // 2 ** 7 - 1
     assert_eq!(
-        DefaultOptions::new().with_varint_length().serialized_size(&b[..]).unwrap(),
+        DefaultOptions::new()
+            .with_varint_length()
+            .serialized_size(&b[..])
+            .unwrap(),
         1
     ); // 250
     assert_eq!(
-        DefaultOptions::new().with_varint_length().serialized_size(&c[..]).unwrap(),
+        DefaultOptions::new()
+            .with_varint_length()
+            .serialized_size(&c[..])
+            .unwrap(),
         (1 + std::mem::size_of::<u16>()) as u64
     ); // 251
     assert_eq!(
-        DefaultOptions::new().with_varint_length().serialized_size(&d[..]).unwrap(),
+        DefaultOptions::new()
+            .with_varint_length()
+            .serialized_size(&d[..])
+            .unwrap(),
         (1 + std::mem::size_of::<u32>()) as u64
     ); // 2 ** 16 + 1
 }


### PR DESCRIPTION
Resolves #319 

This is a continuation of PR #271 based on feedback in that PR. The primary change is to use a config option instead of a feature in order to use varint sequence lengths and discriminants.