### PR TITLE
add mailmap entries

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Ty Overby <ty@pre-alpha.com>
+Ty Overby <ty@pre-alpha.com> <tyoverby@abelay.cs.washington.edu>
+Zoey Riordan <zoey@dos.cafe> <daniel@griffen.io>


### PR DESCRIPTION
This PR adds a .mailmap file (see documentation [here](https://github.com/git/git/blob/master/Documentation/mailmap.txt)) to properly merge contributors in `git --shortlog`