### PR TITLE
remove unsafe code in IoReader

### DIFF
--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -138,27 +138,17 @@ where
         let current_length = self.temp_buffer.len();
         if length > current_length {
             self.temp_buffer.reserve_exact(length - current_length);
+            self.temp_buffer.resize(length, 0);
         }
 
         // Then create a slice with the length as our desired length. This is
         // safe as long as we only write (no reads) to this buffer, because
         // `reserve_exact` above has allocated this space.
-        let buf = unsafe {
-            slice::from_raw_parts_mut(self.temp_buffer.as_mut_ptr(), length)
-        };
 
         // This method is assumed to properly handle slices which include
         // uninitialized bytes (as ours does). See discussion at the link below.
         // https://github.com/servo/bincode/issues/260
-        self.reader.read_exact(buf)?;
-
-        // Only after `read_exact` successfully returns do we set the buffer
-        // length. By doing this after the call to `read_exact`, we can avoid
-        // exposing uninitialized memory in the case of `read_exact` returning
-        // an error.
-        unsafe {
-            self.temp_buffer.set_len(length);
-        }
+        self.reader.read_exact(&mut self.temp_buffer)?;
 
         Ok(())
     }

--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -134,20 +134,13 @@ where
     R: io::Read,
 {
     fn fill_buffer(&mut self, length: usize) -> Result<()> {
-        // We first reserve the space needed in our buffer.
+        // Reserve and fill extra space if needed
         let current_length = self.temp_buffer.len();
         if length > current_length {
             self.temp_buffer.reserve_exact(length - current_length);
             self.temp_buffer.resize(length, 0);
         }
 
-        // Then create a slice with the length as our desired length. This is
-        // safe as long as we only write (no reads) to this buffer, because
-        // `reserve_exact` above has allocated this space.
-
-        // This method is assumed to properly handle slices which include
-        // uninitialized bytes (as ours does). See discussion at the link below.
-        // https://github.com/servo/bincode/issues/260
         self.reader.read_exact(&mut self.temp_buffer)?;
 
         Ok(())


### PR DESCRIPTION
Fully fixes #260 

I ran benchmarks with https://github.com/erickt/rust-serialization-benchmarks and couldn't find any appreciable difference in the time it took to execute. If anything, the new method runs faster.