### PR TITLE
expose default options and serializers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use byteorder;
 use de::read::BincodeRead;
 use error::{ErrorKind, Result};
 use serde;

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,12 @@ pub(crate) use self::internal::*;
 use self::EndianOption::*;
 use self::LimitOption::*;
 
+/// The default options for bincode serialization/deserialization.
+/// Implements OptionsExt to allow building configuration object for non-default settings.
 ///
+/// ### Defaults
+/// By default bincode will use little-endian encoding for mult-byte integers, and will not
+/// limit the number of serialized/deserialized bytes.
 #[derive(Copy, Clone)]
 pub struct DefaultOptions(Infinite);
 
@@ -157,7 +162,13 @@ pub trait OptionsExt: Options + Sized {
 impl<T: Options> OptionsExt for T {}
 
 impl DefaultOptions {
+    /// Get a default configuration object.
     ///
+    /// ### Default Configuration:
+    ///
+    /// | Byte limit | Endianness |
+    /// |------------|------------|
+    /// | Unlimited  | Little     |
     pub fn new() -> DefaultOptions {
         DefaultOptions(Infinite)
     }
@@ -253,14 +264,14 @@ pub struct Config {
     endian: EndianOption,
 }
 
-///
+/// A configuration struct with a user-specified byte limit
 #[derive(Clone, Copy)]
 pub struct WithOtherLimit<O: Options, L: SizeLimit> {
     _options: O,
     pub(crate) new_limit: L,
 }
 
-///
+/// A configuration struct with a user-specified endian order
 #[derive(Clone, Copy)]
 pub struct WithOtherEndian<O: Options, E: ByteOrder> {
     options: O,

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,7 +53,7 @@ impl Options for DefaultOptions {
 ///
 /// ### Options
 /// Endianness: The endianness with which multi-byte integers will be read/written.  *default: little endian*
-/// 
+///
 /// Limit: The maximum number of bytes that will be read/written in a bincode serialize/deserialize. *default: unlimited*
 ///
 /// ### Byte Limit Details
@@ -545,7 +545,7 @@ mod internal {
         fn limit(&mut self) -> &mut Self::Limit {
             (*self).limit()
         }
-    } 
+    }
 
     /// A trait for stopping serialization and deserialization when a certain limit has been reached.
     pub trait SizeLimit {

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,11 +109,13 @@ pub struct Config {
     endian: EndianOption,
 }
 
+///
 pub struct WithOtherLimit<O: Options, L: SizeLimit> {
     _options: O,
     pub(crate) new_limit: L,
 }
 
+///
 pub struct WithOtherEndian<O: Options, E: ByteOrder> {
     options: O,
     _endian: PhantomData<E>,
@@ -351,7 +353,7 @@ impl Config {
         R: BincodeRead<'a>,
     {
         config_map!(self, opts => {
-            let mut deserializer = ::de::Deserializer::new(reader, opts);
+            let mut deserializer = ::de::Deserializer::with_bincode_read(reader, opts);
             acceptor.accept(&mut deserializer)
         })
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -538,10 +538,11 @@ mod internal {
         fn limit(&mut self) -> &mut Self::Limit;
     }
 
-    impl<T: Options> Options for &mut T {
-        type Limit = T::Limit;
-        type Endian = T::Endian;
+    impl<'a, O: Options> Options for &'a mut O {
+        type Limit = O::Limit;
+        type Endian = O::Endian;
 
+        #[inline(always)]
         fn limit(&mut self) -> &mut Self::Limit {
             (*self).limit()
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,32 +10,39 @@ use {DeserializerAcceptor, SerializerAcceptor};
 use self::EndianOption::*;
 use self::LimitOption::*;
 
-struct DefaultOptions(Infinite);
+///
+pub struct DefaultOptions(Infinite);
 
-pub(crate) trait Options {
+pub trait Options {
     type Limit: SizeLimit + 'static;
     type Endian: ByteOrder + 'static;
 
     fn limit(&mut self) -> &mut Self::Limit;
 }
 
-pub(crate) trait OptionsExt: Options + Sized {
+///
+pub trait OptionsExt: Options + Sized {
+    ///
     fn with_no_limit(self) -> WithOtherLimit<Self, Infinite> {
         WithOtherLimit::new(self, Infinite)
     }
 
+    ///
     fn with_limit(self, limit: u64) -> WithOtherLimit<Self, Bounded> {
         WithOtherLimit::new(self, Bounded(limit))
     }
 
+    ///
     fn with_little_endian(self) -> WithOtherEndian<Self, LittleEndian> {
         WithOtherEndian::new(self)
     }
 
+    ///
     fn with_big_endian(self) -> WithOtherEndian<Self, BigEndian> {
         WithOtherEndian::new(self)
     }
 
+    ///
     fn with_native_endian(self) -> WithOtherEndian<Self, NativeEndian> {
         WithOtherEndian::new(self)
     }
@@ -54,7 +61,8 @@ impl<'a, O: Options> Options for &'a mut O {
 impl<T: Options> OptionsExt for T {}
 
 impl DefaultOptions {
-    fn new() -> DefaultOptions {
+    ///
+    pub fn new() -> DefaultOptions {
         DefaultOptions(Infinite)
     }
 }
@@ -101,12 +109,12 @@ pub struct Config {
     endian: EndianOption,
 }
 
-pub(crate) struct WithOtherLimit<O: Options, L: SizeLimit> {
+pub struct WithOtherLimit<O: Options, L: SizeLimit> {
     _options: O,
     pub(crate) new_limit: L,
 }
 
-pub(crate) struct WithOtherEndian<O: Options, E: ByteOrder> {
+pub struct WithOtherEndian<O: Options, E: ByteOrder> {
     options: O,
     _endian: PhantomData<E>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,6 +89,17 @@ pub trait OptionsExt: Options + Sized {
         ::internal::deserialize(bytes, self.clone())
     }
 
+    /// TODO: document
+    #[doc(hidden)]
+    #[inline(always)]
+    fn deserialize_in_place<'a, R, T>(&self, reader: R, place: &mut T) -> Result<()>
+    where
+        R: BincodeRead<'a>,
+        T: serde::de::Deserialize<'a>,
+    {
+        ::internal::deserialize_in_place(reader, self.clone(), place)
+    }
+
     /// Deserializes a slice of bytes with state `seed` using this configuration.
     #[inline(always)]
     fn deserialize_seed<'a, T: serde::de::DeserializeSeed<'a>>(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use byteorder::{BigEndian, ByteOrder, LittleEndian, NativeEndian};
 use de::read::BincodeRead;
-use error::Result;
+use error::{Result, ErrorKind};
 use serde;
 use std::io::{Read, Write};
 use std::marker::PhantomData;

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -32,24 +32,24 @@ pub struct Deserializer<R, O: Options> {
 
 impl<'de, R: BincodeRead<'de>, O: Options> Deserializer<R, O> {
     /// Creates a new Deserializer with a given `Read`er and options.
-    pub fn new<IR: Read>(r: IR, options: O) -> Deserializer<IoReader<IR>, O> {
-        Deserializer { reader: IoReader::new(r), options }
+    pub fn with_reader<IR: Read>(r: IR, options: O) -> Deserializer<IoReader<IR>, O> {
+        Deserializer {
+            reader: IoReader::new(r),
+            options,
+        }
     }
-    
+
     /// Creates a new Deserializer that will read from the given slice.
     pub fn from_slice(slice: &'de [u8], options: O) -> Deserializer<SliceReader<'de>, O> {
         Deserializer {
             reader: SliceReader::new(slice),
-            options: options,
+            options,
         }
     }
 
     /// Creates a new Deserializer with the given `BincodeRead`er
     pub fn with_bincode_read(r: R, options: O) -> Deserializer<R, O> {
-        Deserializer {
-            reader: r,
-            options: options,
-        }
+        Deserializer { reader: r, options }
     }
 
     fn read_bytes(&mut self, count: u64) -> Result<()> {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -80,7 +80,7 @@ macro_rules! impl_nums {
             where V: serde::de::Visitor<'de>,
         {
             self.read_type::<$ty>()?;
-            let value = self.reader.$reader_method::<<<O as Options>::Endian as BincodeByteOrder>::Endian>()?;
+            let value = self.reader.$reader_method::<<O::Endian as BincodeByteOrder>::Endian>()?;
             visitor.$visitor_method(value)
         }
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -3,12 +3,13 @@ use std::io::Read;
 
 use self::read::{BincodeRead, IoReader, SliceReader};
 use byteorder::ReadBytesExt;
-use internal::SizeLimit;
+use config::SizeLimit;
 use serde;
 use serde::de::Error as DeError;
 use serde::de::IntoDeserializer;
 use {Error, ErrorKind, Result};
 
+/// Specialized ways to read data into bincode.
 pub mod read;
 
 /// A Deserializer that reads bytes from a buffer.
@@ -30,12 +31,12 @@ pub struct Deserializer<R, O: Options> {
 }
 
 impl<'de, R: BincodeRead<'de>, O: Options> Deserializer<R, O> {
-    /// Creates a new Deserializer with a given `Read`er and a size_limit.
+    /// Creates a new Deserializer with a given `Read`er and options.
     pub fn new<IR: Read>(r: IR, options: O) -> Deserializer<IoReader<IR>, O> {
         Deserializer { reader: IoReader::new(r), options }
     }
     
-    ///
+    /// Creates a new Deserializer that will read from the given slice.
     pub fn from_slice(slice: &'de [u8], options: O) -> Deserializer<SliceReader<'de>, O> {
         Deserializer {
             reader: SliceReader::new(slice),
@@ -43,7 +44,7 @@ impl<'de, R: BincodeRead<'de>, O: Options> Deserializer<R, O> {
         }
     }
 
-    ///
+    /// Creates a new Deserializer with the given `BincodeRead`er
     pub fn with_bincode_read(r: R, options: O) -> Deserializer<R, O> {
         Deserializer {
             reader: r,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,4 +1,4 @@
-use config::Options;
+use config::{BincodeByteOrder, Options};
 use std::io::Read;
 
 use self::read::{BincodeRead, IoReader, SliceReader};
@@ -80,7 +80,7 @@ macro_rules! impl_nums {
             where V: serde::de::Visitor<'de>,
         {
             self.read_type::<$ty>()?;
-            let value = self.reader.$reader_method::<O::Endian>()?;
+            let value = self.reader.$reader_method::<<<O as Options>::Endian as BincodeByteOrder>::Endian>()?;
             visitor.$visitor_method(value)
         }
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -24,14 +24,14 @@ pub mod read;
 /// serde::Deserialize::deserialize(&mut deserializer);
 /// let bytes_read = d.bytes_read();
 /// ```
-pub(crate) struct Deserializer<R, O: Options> {
+pub struct Deserializer<R, O: Options> {
     reader: R,
     options: O,
 }
 
 impl<'de, R: BincodeRead<'de>, O: Options> Deserializer<R, O> {
     /// Creates a new Deserializer with a given `Read`er and a size_limit.
-    pub(crate) fn new(r: R, options: O) -> Deserializer<R, O> {
+    pub fn new(r: R, options: O) -> Deserializer<R, O> {
         Deserializer { reader: r, options }
     }
 

--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -27,15 +27,11 @@ pub trait BincodeRead<'storage>: io::Read {
 }
 
 /// A BincodeRead implementation for byte slices
-/// NOT A PART OF THE STABLE PUBLIC API
-#[doc(hidden)]
 pub struct SliceReader<'storage> {
     slice: &'storage [u8],
 }
 
-/// A BincodeRead implementation for io::Readers
-/// NOT A PART OF THE STABLE PUBLIC API
-#[doc(hidden)]
+/// A BincodeRead implementation for `io::Read`ers
 pub struct IoReader<R> {
     reader: R,
     temp_buffer: Vec<u8>,
@@ -43,7 +39,7 @@ pub struct IoReader<R> {
 
 impl<'storage> SliceReader<'storage> {
     /// Constructs a slice reader
-    pub fn new(bytes: &'storage [u8]) -> SliceReader<'storage> {
+    pub(crate) fn new(bytes: &'storage [u8]) -> SliceReader<'storage> {
         SliceReader { slice: bytes }
     }
 
@@ -60,7 +56,7 @@ impl<'storage> SliceReader<'storage> {
 
 impl<R> IoReader<R> {
     /// Constructs an IoReadReader
-    pub fn new(r: R) -> IoReader<R> {
+    pub(crate) fn new(r: R) -> IoReader<R> {
         IoReader {
             reader: r,
             temp_buffer: vec![],

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -143,7 +143,7 @@ where
     deserialize_from_custom_seed(seed, reader, options)
 }
 
-pub(crate) trait SizeLimit: Clone {
+pub trait SizeLimit: Clone {
     /// Tells the SizeLimit that a certain number of bytes has been
     /// read or written.  Returns Err if the limit has been exceeded.
     fn add(&mut self, n: u64) -> Result<()>;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -2,9 +2,9 @@ use serde;
 use std::io::{Read, Write};
 use std::marker::PhantomData;
 
-use config::{Options, OptionsExt, SizeLimit, Infinite};
+use config::{Infinite, Options, OptionsExt, SizeLimit};
 use de::read::BincodeRead;
-use {ErrorKind, Result};
+use Result;
 
 #[derive(Clone)]
 struct CountSize<L: SizeLimit> {
@@ -28,7 +28,7 @@ where
     serde::Serialize::serialize(value, &mut serializer)
 }
 
-pub(crate) fn serialize<T: ?Sized, O>(value: &T, mut options: O) -> Result<Vec<u8>>
+pub(crate) fn serialize<T: ?Sized, O>(value: &T, options: O) -> Result<Vec<u8>>
 where
     T: serde::Serialize,
     O: Options,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -111,7 +111,7 @@ where
     T: serde::de::DeserializeSeed<'a>,
     O: Options,
 {
-    let mut deserializer = ::de::Deserializer::<_, O>::new(reader, options);
+    let mut deserializer = ::de::Deserializer::<_, O>::with_bincode_read(reader, options);
     seed.deserialize(&mut deserializer)
 }
 
@@ -121,7 +121,7 @@ where
     T: serde::de::Deserialize<'a>,
     O: Options,
 {
-    let mut deserializer = ::de::Deserializer::<_, _>::new(reader, options);
+    let mut deserializer = ::de::Deserializer::<_, _>::with_bincode_read(reader, options);
     serde::Deserialize::deserialize_in_place(&mut deserializer, place)
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -2,7 +2,7 @@ use serde;
 use std::io::{Read, Write};
 use std::marker::PhantomData;
 
-use config::{Options, OptionsExt};
+use config::{Options, OptionsExt, SizeLimit};
 use de::read::BincodeRead;
 use {ErrorKind, Result};
 
@@ -141,51 +141,4 @@ where
     let reader = ::de::read::SliceReader::new(bytes);
     let options = ::config::WithOtherLimit::new(options, Infinite);
     deserialize_from_custom_seed(seed, reader, options)
-}
-
-pub trait SizeLimit: Clone {
-    /// Tells the SizeLimit that a certain number of bytes has been
-    /// read or written.  Returns Err if the limit has been exceeded.
-    fn add(&mut self, n: u64) -> Result<()>;
-    /// Returns the hard limit (if one exists)
-    fn limit(&self) -> Option<u64>;
-}
-
-/// A SizeLimit that restricts serialized or deserialized messages from
-/// exceeding a certain byte length.
-#[derive(Copy, Clone)]
-pub struct Bounded(pub u64);
-
-/// A SizeLimit without a limit!
-/// Use this if you don't care about the size of encoded or decoded messages.
-#[derive(Copy, Clone)]
-pub struct Infinite;
-
-impl SizeLimit for Bounded {
-    #[inline(always)]
-    fn add(&mut self, n: u64) -> Result<()> {
-        if self.0 >= n {
-            self.0 -= n;
-            Ok(())
-        } else {
-            Err(Box::new(ErrorKind::SizeLimit))
-        }
-    }
-
-    #[inline(always)]
-    fn limit(&self) -> Option<u64> {
-        Some(self.0)
-    }
-}
-
-impl SizeLimit for Infinite {
-    #[inline(always)]
-    fn add(&mut self, _: u64) -> Result<()> {
-        Ok(())
-    }
-
-    #[inline(always)]
-    fn limit(&self) -> Option<u64> {
-        None
-    }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -21,7 +21,7 @@ where
     if options.limit().limit().is_some() {
         // "compute" the size for the side-effect
         // of returning Err if the bound was reached.
-        serialized_size(value, &mut options)?;
+        serialized_size(value, options.clone())?;
     }
 
     let mut serializer = ::ser::Serializer::<_, O>::new(writer, options);
@@ -31,10 +31,10 @@ where
 pub(crate) fn serialize<T: ?Sized, O>(value: &T, mut options: O) -> Result<Vec<u8>>
 where
     T: serde::Serialize,
-    O: Options + Clone,
+    O: Options,
 {
     let mut writer = {
-        let actual_size = serialized_size(value, &mut options)?;
+        let actual_size = serialized_size(value, options.clone())?;
         Vec::with_capacity(actual_size as usize)
     };
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -31,7 +31,7 @@ where
 pub(crate) fn serialize<T: ?Sized, O>(value: &T, mut options: O) -> Result<Vec<u8>>
 where
     T: serde::Serialize,
-    O: Options,
+    O: Options + Clone,
 {
     let mut writer = {
         let actual_size = serialized_size(value, &mut options)?;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -2,7 +2,7 @@ use serde;
 use std::io::{Read, Write};
 use std::marker::PhantomData;
 
-use config::{Options, OptionsExt, SizeLimit};
+use config::{Options, OptionsExt, SizeLimit, Infinite};
 use de::read::BincodeRead;
 use {ErrorKind, Result};
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -41,7 +41,7 @@ where
     T: serde::Serialize,
 {
     let mut size_counter = ::ser::SizeChecker {
-        options: options,
+        options,
         total: 0,
     };
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -40,10 +40,7 @@ pub(crate) fn serialized_size<T: ?Sized, O: Options>(value: &T, options: O) -> R
 where
     T: serde::Serialize,
 {
-    let mut size_counter = ::ser::SizeChecker {
-        options,
-        total: 0,
-    };
+    let mut size_counter = ::ser::SizeChecker { options, total: 0 };
 
     let result = value.serialize(&mut size_counter);
     result.map(|_| size_counter.total)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub use ser::Serializer;
 /// |------------|------------|
 /// | Unlimited  | Little     |
 #[inline(always)]
-#[deprecated(since="1.3.0", note="please use `DefaultOptions::new()` instead")]
+#[deprecated(since = "1.3.0", note = "please use `DefaultOptions::new()` instead")]
 pub fn config() -> Config {
     Config::new()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ where
     W: std::io::Write,
     T: serde::Serialize,
 {
-    config().serialize_into(writer, value)
+    DefaultOptions::new().serialize_into(writer, value)
 }
 
 /// Serializes a serializable object into a `Vec` of bytes using the default configuration.
@@ -78,7 +78,7 @@ pub fn serialize<T: ?Sized>(value: &T) -> Result<Vec<u8>>
 where
     T: serde::Serialize,
 {
-    config().serialize(value)
+    DefaultOptions::new().serialize(value)
 }
 
 /// Deserializes an object directly from a `Read`er using the default configuration.
@@ -89,7 +89,7 @@ where
     R: std::io::Read,
     T: serde::de::DeserializeOwned,
 {
-    config().deserialize_from(reader)
+    DefaultOptions::new().deserialize_from(reader)
 }
 
 /// Deserializes an object from a custom `BincodeRead`er using the default configuration.
@@ -102,7 +102,7 @@ where
     R: de::read::BincodeRead<'a>,
     T: serde::de::DeserializeOwned,
 {
-    config().deserialize_from_custom(reader)
+    DefaultOptions::new().deserialize_from_custom(reader)
 }
 
 /// Only use this if you know what you're doing.
@@ -114,7 +114,7 @@ where
     T: serde::de::Deserialize<'a>,
     R: BincodeRead<'a>,
 {
-    config().deserialize_in_place(reader, place)
+    DefaultOptions::new().deserialize_in_place(reader, place)
 }
 
 /// Deserializes a slice of bytes into an instance of `T` using the default configuration.
@@ -122,7 +122,7 @@ pub fn deserialize<'a, T>(bytes: &'a [u8]) -> Result<T>
 where
     T: serde::de::Deserialize<'a>,
 {
-    config().deserialize(bytes)
+    DefaultOptions::new().deserialize(bytes)
 }
 
 /// Returns the size that an object would be if serialized using Bincode with the default configuration.
@@ -130,5 +130,5 @@ pub fn serialized_size<T: ?Sized>(value: &T) -> Result<u64>
 where
     T: serde::Serialize,
 {
-    config().serialized_size(value)
+    DefaultOptions::new().serialized_size(value)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,11 @@ mod error;
 mod internal;
 mod ser;
 
-pub use config::Config;
+pub use config::{Config, DefaultOptions, OptionsExt};
 pub use de::read::{BincodeRead, IoReader, SliceReader};
 pub use error::{Error, ErrorKind, Result};
+pub use de::Deserializer;
+pub use ser::Serializer;
 
 /// An object that implements this trait can be passed a
 /// serde::Deserializer without knowing its concrete type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,8 @@ mod error;
 mod internal;
 mod ser;
 
-pub use config::{Config, DefaultOptions, OptionsExt};
+pub use config::{Config, DefaultOptions, OptionsExt, WithOtherLimit, WithOtherEndian};
+pub use internal::{Bounded, Infinite};
 pub use de::read::{BincodeRead, IoReader, SliceReader};
 pub use error::{Error, ErrorKind, Result};
 pub use de::Deserializer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,15 +33,17 @@ extern crate byteorder;
 #[macro_use]
 extern crate serde;
 
-mod config;
-mod de;
+/// Configuration settings for bincode.
+pub mod config;
+/// Deserialize bincode data to a Rust data structure.
+pub mod de;
+
 mod error;
 mod internal;
 mod ser;
 
-pub use config::{Config, DefaultOptions, OptionsExt, WithOtherLimit, WithOtherEndian};
-pub use internal::{Bounded, Infinite};
-pub use de::read::{BincodeRead, IoReader, SliceReader};
+pub use config::{Config, DefaultOptions, OptionsExt};
+pub use de::read::BincodeRead;
 pub use error::{Error, ErrorKind, Result};
 pub use de::Deserializer;
 pub use ser::Serializer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,37 +44,9 @@ mod ser;
 
 pub use config::{Config, DefaultOptions, OptionsExt};
 pub use de::read::BincodeRead;
-pub use error::{Error, ErrorKind, Result};
 pub use de::Deserializer;
+pub use error::{Error, ErrorKind, Result};
 pub use ser::Serializer;
-
-/// An object that implements this trait can be passed a
-/// serde::Deserializer without knowing its concrete type.
-///
-/// This trait should be used only for `with_deserializer` functions.
-#[doc(hidden)]
-pub trait DeserializerAcceptor<'a> {
-    /// The return type for the accept method
-    type Output;
-    /// Accept a serde::Deserializer and do whatever you want with it.
-    fn accept<T>(self, T) -> Self::Output
-    where
-        T: serde::Deserializer<'a, Error = Error>;
-}
-
-/// An object that implements this trait can be passed a
-/// serde::Serializer without knowing its concrete type.
-///
-/// This trait should be used only for `with_serializer` functions.
-#[doc(hidden)]
-pub trait SerializerAcceptor {
-    /// The return type for the accept method
-    type Output;
-    /// Accept a serde::Serializer and do whatever you want with it.
-    fn accept<T>(self, T) -> Self::Output
-    where
-        T: serde::Serializer<Ok = (), Error = Error>;
-}
 
 /// Get a default configuration object.
 ///
@@ -84,6 +56,7 @@ pub trait SerializerAcceptor {
 /// |------------|------------|
 /// | Unlimited  | Little     |
 #[inline(always)]
+#[deprecated(since="1.3.0", note="please use `DefaultOptions::new()` instead")]
 pub fn config() -> Config {
     Config::new()
 }
@@ -158,26 +131,4 @@ where
     T: serde::Serialize,
 {
     config().serialized_size(value)
-}
-
-/// Executes the acceptor with a serde::Deserializer instance.
-/// NOT A PART OF THE STABLE PUBLIC API
-#[doc(hidden)]
-pub fn with_deserializer<'a, A, R>(reader: R, acceptor: A) -> A::Output
-where
-    A: DeserializerAcceptor<'a>,
-    R: BincodeRead<'a>,
-{
-    config().with_deserializer(reader, acceptor)
-}
-
-/// Executes the acceptor with a serde::Serializer instance.
-/// NOT A PART OF THE STABLE PUBLIC API
-#[doc(hidden)]
-pub fn with_serializer<A, W>(writer: W, acceptor: A) -> A::Output
-where
-    A: SerializerAcceptor,
-    W: std::io::Write,
-{
-    config().with_serializer(writer, acceptor)
 }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -237,11 +237,15 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
 
 pub(crate) struct SizeChecker<O: Options> {
     pub options: O,
+    pub total: u64,
 }
 
 impl<O: Options> SizeChecker<O> {
     fn add_raw(&mut self, size: u64) -> Result<()> {
-        self.options.limit().add(size)
+        self.options.limit().add(size)?;
+        self.total += size;
+
+        Ok(())
     }
 
     fn add_value<T>(&mut self, t: T) -> Result<()> {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -16,7 +16,7 @@ use config::Options;
 ///
 /// This struct should not be used often.
 /// For most cases, prefer the `encode_into` function.
-pub(crate) struct Serializer<W, O: Options> {
+pub struct Serializer<W, O: Options> {
     writer: W,
     _options: O,
 }
@@ -418,7 +418,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
     }
 }
 
-pub(crate) struct Compound<'a, W: 'a, O: Options + 'a> {
+pub struct Compound<'a, W: 'a, O: Options + 'a> {
     ser: &'a mut Serializer<W, O>,
 }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -7,7 +7,7 @@ use byteorder::WriteBytesExt;
 
 use super::config::SizeLimit;
 use super::{Error, ErrorKind, Result};
-use config::Options;
+use config::{BincodeByteOrder, Options};
 
 /// An Serializer that encodes values directly into a Writer.
 ///
@@ -61,15 +61,15 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     }
 
     fn serialize_u16(self, v: u16) -> Result<()> {
-        self.writer.write_u16::<O::Endian>(v).map_err(Into::into)
+        self.writer.write_u16::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_u32(self, v: u32) -> Result<()> {
-        self.writer.write_u32::<O::Endian>(v).map_err(Into::into)
+        self.writer.write_u32::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_u64(self, v: u64) -> Result<()> {
-        self.writer.write_u64::<O::Endian>(v).map_err(Into::into)
+        self.writer.write_u64::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_i8(self, v: i8) -> Result<()> {
@@ -77,33 +77,33 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     }
 
     fn serialize_i16(self, v: i16) -> Result<()> {
-        self.writer.write_i16::<O::Endian>(v).map_err(Into::into)
+        self.writer.write_i16::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_i32(self, v: i32) -> Result<()> {
-        self.writer.write_i32::<O::Endian>(v).map_err(Into::into)
+        self.writer.write_i32::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_i64(self, v: i64) -> Result<()> {
-        self.writer.write_i64::<O::Endian>(v).map_err(Into::into)
+        self.writer.write_i64::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
     }
 
     serde_if_integer128! {
         fn serialize_u128(self, v: u128) -> Result<()> {
-            self.writer.write_u128::<O::Endian>(v).map_err(Into::into)
+            self.writer.write_u128::<<O::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
         }
 
         fn serialize_i128(self, v: i128) -> Result<()> {
-            self.writer.write_i128::<O::Endian>(v).map_err(Into::into)
+            self.writer.write_i128::<<O::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
         }
     }
 
     fn serialize_f32(self, v: f32) -> Result<()> {
-        self.writer.write_f32::<O::Endian>(v).map_err(Into::into)
+        self.writer.write_f32::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_f64(self, v: f64) -> Result<()> {
-        self.writer.write_f64::<O::Endian>(v).map_err(Into::into)
+        self.writer.write_f64::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -61,15 +61,21 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     }
 
     fn serialize_u16(self, v: u16) -> Result<()> {
-        self.writer.write_u16::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
+        self.writer
+            .write_u16::<<O::Endian as BincodeByteOrder>::Endian>(v)
+            .map_err(Into::into)
     }
 
     fn serialize_u32(self, v: u32) -> Result<()> {
-        self.writer.write_u32::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
+        self.writer
+            .write_u32::<<O::Endian as BincodeByteOrder>::Endian>(v)
+            .map_err(Into::into)
     }
 
     fn serialize_u64(self, v: u64) -> Result<()> {
-        self.writer.write_u64::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
+        self.writer
+            .write_u64::<<O::Endian as BincodeByteOrder>::Endian>(v)
+            .map_err(Into::into)
     }
 
     fn serialize_i8(self, v: i8) -> Result<()> {
@@ -77,15 +83,21 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     }
 
     fn serialize_i16(self, v: i16) -> Result<()> {
-        self.writer.write_i16::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
+        self.writer
+            .write_i16::<<O::Endian as BincodeByteOrder>::Endian>(v)
+            .map_err(Into::into)
     }
 
     fn serialize_i32(self, v: i32) -> Result<()> {
-        self.writer.write_i32::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
+        self.writer
+            .write_i32::<<O::Endian as BincodeByteOrder>::Endian>(v)
+            .map_err(Into::into)
     }
 
     fn serialize_i64(self, v: i64) -> Result<()> {
-        self.writer.write_i64::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
+        self.writer
+            .write_i64::<<O::Endian as BincodeByteOrder>::Endian>(v)
+            .map_err(Into::into)
     }
 
     serde_if_integer128! {
@@ -99,11 +111,15 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     }
 
     fn serialize_f32(self, v: f32) -> Result<()> {
-        self.writer.write_f32::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
+        self.writer
+            .write_f32::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v)
+            .map_err(Into::into)
     }
 
     fn serialize_f64(self, v: f64) -> Result<()> {
-        self.writer.write_f64::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v).map_err(Into::into)
+        self.writer
+            .write_f64::<<<O as Options>::Endian as BincodeByteOrder>::Endian>(v)
+            .map_err(Into::into)
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -5,7 +5,7 @@ use serde;
 
 use byteorder::WriteBytesExt;
 
-use super::internal::SizeLimit;
+use super::config::SizeLimit;
 use super::{Error, ErrorKind, Result};
 use config::Options;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -33,8 +33,14 @@ where
     }
 
     {
-        let encoded = DefaultOptions::new().with_big_endian().serialize(&element).unwrap();
-        let decoded = DefaultOptions::new().with_big_endian().deserialize(&encoded[..]).unwrap();
+        let encoded = DefaultOptions::new()
+            .with_big_endian()
+            .serialize(&element)
+            .unwrap();
+        let decoded = DefaultOptions::new()
+            .with_big_endian()
+            .deserialize(&encoded[..])
+            .unwrap();
         let decoded_reader = DefaultOptions::new()
             .with_big_endian()
             .deserialize_from(&mut &encoded[..])
@@ -259,11 +265,15 @@ fn deserializing_errors() {
 #[test]
 fn too_big_deserialize() {
     let serialized = vec![0, 0, 0, 3];
-    let deserialized: Result<u32> = DefaultOptions::new().with_limit(3).deserialize_from(&mut &serialized[..]);
+    let deserialized: Result<u32> = DefaultOptions::new()
+        .with_limit(3)
+        .deserialize_from(&mut &serialized[..]);
     assert!(deserialized.is_err());
 
     let serialized = vec![0, 0, 0, 3];
-    let deserialized: Result<u32> = DefaultOptions::new().with_limit(4).deserialize_from(&mut &serialized[..]);
+    let deserialized: Result<u32> = DefaultOptions::new()
+        .with_limit(4)
+        .deserialize_from(&mut &serialized[..]);
     assert!(deserialized.is_ok());
 }
 
@@ -283,18 +293,29 @@ fn char_serialization() {
 #[test]
 fn too_big_char_deserialize() {
     let serialized = vec![0x41];
-    let deserialized: Result<char> = DefaultOptions::new().with_limit(1).deserialize_from(&mut &serialized[..]);
+    let deserialized: Result<char> = DefaultOptions::new()
+        .with_limit(1)
+        .deserialize_from(&mut &serialized[..]);
     assert!(deserialized.is_ok());
     assert_eq!(deserialized.unwrap(), 'A');
 }
 
 #[test]
 fn too_big_serialize() {
-    assert!(DefaultOptions::new().with_limit(3).serialize(&0u32).is_err());
+    assert!(DefaultOptions::new()
+        .with_limit(3)
+        .serialize(&0u32)
+        .is_err());
     assert!(DefaultOptions::new().with_limit(4).serialize(&0u32).is_ok());
 
-    assert!(DefaultOptions::new().with_limit(8 + 4).serialize(&"abcde").is_err());
-    assert!(DefaultOptions::new().with_limit(8 + 5).serialize(&"abcde").is_ok());
+    assert!(DefaultOptions::new()
+        .with_limit(8 + 4)
+        .serialize(&"abcde")
+        .is_err());
+    assert!(DefaultOptions::new()
+        .with_limit(8 + 5)
+        .serialize(&"abcde")
+        .is_ok());
 }
 
 #[test]
@@ -314,12 +335,48 @@ fn test_serialized_size() {
 #[test]
 fn test_serialized_size_bounded() {
     // JUST RIGHT
-    assert!(DefaultOptions::new().with_limit(1).serialized_size(&0u8).unwrap() == 1);
-    assert!(DefaultOptions::new().with_limit(2).serialized_size(&0u16).unwrap() == 2);
-    assert!(DefaultOptions::new().with_limit(4).serialized_size(&0u32).unwrap() == 4);
-    assert!(DefaultOptions::new().with_limit(8).serialized_size(&0u64).unwrap() == 8);
-    assert!(DefaultOptions::new().with_limit(8).serialized_size(&"").unwrap() == 8);
-    assert!(DefaultOptions::new().with_limit(8 + 1).serialized_size(&"a").unwrap() == 8 + 1);
+    assert!(
+        DefaultOptions::new()
+            .with_limit(1)
+            .serialized_size(&0u8)
+            .unwrap()
+            == 1
+    );
+    assert!(
+        DefaultOptions::new()
+            .with_limit(2)
+            .serialized_size(&0u16)
+            .unwrap()
+            == 2
+    );
+    assert!(
+        DefaultOptions::new()
+            .with_limit(4)
+            .serialized_size(&0u32)
+            .unwrap()
+            == 4
+    );
+    assert!(
+        DefaultOptions::new()
+            .with_limit(8)
+            .serialized_size(&0u64)
+            .unwrap()
+            == 8
+    );
+    assert!(
+        DefaultOptions::new()
+            .with_limit(8)
+            .serialized_size(&"")
+            .unwrap()
+            == 8
+    );
+    assert!(
+        DefaultOptions::new()
+            .with_limit(8 + 1)
+            .serialized_size(&"a")
+            .unwrap()
+            == 8 + 1
+    );
     assert!(
         DefaultOptions::new()
             .with_limit(8 + 3 * 4)
@@ -328,12 +385,30 @@ fn test_serialized_size_bounded() {
             == 8 + 3 * 4
     );
     // Below
-    assert!(DefaultOptions::new().with_limit(0).serialized_size(&0u8).is_err());
-    assert!(DefaultOptions::new().with_limit(1).serialized_size(&0u16).is_err());
-    assert!(DefaultOptions::new().with_limit(3).serialized_size(&0u32).is_err());
-    assert!(DefaultOptions::new().with_limit(7).serialized_size(&0u64).is_err());
-    assert!(DefaultOptions::new().with_limit(7).serialized_size(&"").is_err());
-    assert!(DefaultOptions::new().with_limit(8 + 0).serialized_size(&"a").is_err());
+    assert!(DefaultOptions::new()
+        .with_limit(0)
+        .serialized_size(&0u8)
+        .is_err());
+    assert!(DefaultOptions::new()
+        .with_limit(1)
+        .serialized_size(&0u16)
+        .is_err());
+    assert!(DefaultOptions::new()
+        .with_limit(3)
+        .serialized_size(&0u32)
+        .is_err());
+    assert!(DefaultOptions::new()
+        .with_limit(7)
+        .serialized_size(&0u64)
+        .is_err());
+    assert!(DefaultOptions::new()
+        .with_limit(7)
+        .serialized_size(&"")
+        .is_err());
+    assert!(DefaultOptions::new()
+        .with_limit(8 + 0)
+        .serialized_size(&"a")
+        .is_err());
     assert!(DefaultOptions::new()
         .with_limit(8 + 3 * 4 - 1)
         .serialized_size(&vec![0u32, 1u32, 2u32])
@@ -458,7 +533,10 @@ fn serde_bytes() {
 fn endian_difference() {
     let x = 10u64;
     let little = serialize(&x).unwrap();
-    let big = DefaultOptions::new().with_big_endian().serialize(&x).unwrap();
+    let big = DefaultOptions::new()
+        .with_big_endian()
+        .serialize(&x)
+        .unwrap();
     assert_ne!(little, big);
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,8 +13,8 @@ use std::fmt::{self, Debug};
 use std::result::Result as StdResult;
 
 use bincode::{
-    config, deserialize, deserialize_from, deserialize_in_place, serialize, serialized_size,
-    ErrorKind, Result,
+    deserialize, deserialize_from, deserialize_in_place, serialize, serialized_size,
+    DefaultOptions, ErrorKind, OptionsExt, Result,
 };
 use serde::de::{Deserialize, DeserializeSeed, Deserializer, SeqAccess, Visitor};
 
@@ -33,10 +33,10 @@ where
     }
 
     {
-        let encoded = config().big_endian().serialize(&element).unwrap();
-        let decoded = config().big_endian().deserialize(&encoded[..]).unwrap();
-        let decoded_reader = config()
-            .big_endian()
+        let encoded = DefaultOptions::new().with_big_endian().serialize(&element).unwrap();
+        let decoded = DefaultOptions::new().with_big_endian().deserialize(&encoded[..]).unwrap();
+        let decoded_reader = DefaultOptions::new()
+            .with_big_endian()
             .deserialize_from(&mut &encoded[..])
             .unwrap();
 
@@ -259,11 +259,11 @@ fn deserializing_errors() {
 #[test]
 fn too_big_deserialize() {
     let serialized = vec![0, 0, 0, 3];
-    let deserialized: Result<u32> = config().limit(3).deserialize_from(&mut &serialized[..]);
+    let deserialized: Result<u32> = DefaultOptions::new().with_limit(3).deserialize_from(&mut &serialized[..]);
     assert!(deserialized.is_err());
 
     let serialized = vec![0, 0, 0, 3];
-    let deserialized: Result<u32> = config().limit(4).deserialize_from(&mut &serialized[..]);
+    let deserialized: Result<u32> = DefaultOptions::new().with_limit(4).deserialize_from(&mut &serialized[..]);
     assert!(deserialized.is_ok());
 }
 
@@ -271,8 +271,8 @@ fn too_big_deserialize() {
 fn char_serialization() {
     let chars = "Aa\0☺♪";
     for c in chars.chars() {
-        let encoded = config()
-            .limit(4)
+        let encoded = DefaultOptions::new()
+            .with_limit(4)
             .serialize(&c)
             .expect("serializing char failed");
         let decoded: char = deserialize(&encoded).expect("deserializing failed");
@@ -283,18 +283,18 @@ fn char_serialization() {
 #[test]
 fn too_big_char_deserialize() {
     let serialized = vec![0x41];
-    let deserialized: Result<char> = config().limit(1).deserialize_from(&mut &serialized[..]);
+    let deserialized: Result<char> = DefaultOptions::new().with_limit(1).deserialize_from(&mut &serialized[..]);
     assert!(deserialized.is_ok());
     assert_eq!(deserialized.unwrap(), 'A');
 }
 
 #[test]
 fn too_big_serialize() {
-    assert!(config().limit(3).serialize(&0u32).is_err());
-    assert!(config().limit(4).serialize(&0u32).is_ok());
+    assert!(DefaultOptions::new().with_limit(3).serialize(&0u32).is_err());
+    assert!(DefaultOptions::new().with_limit(4).serialize(&0u32).is_ok());
 
-    assert!(config().limit(8 + 4).serialize(&"abcde").is_err());
-    assert!(config().limit(8 + 5).serialize(&"abcde").is_ok());
+    assert!(DefaultOptions::new().with_limit(8 + 4).serialize(&"abcde").is_err());
+    assert!(DefaultOptions::new().with_limit(8 + 5).serialize(&"abcde").is_ok());
 }
 
 #[test]
@@ -314,28 +314,28 @@ fn test_serialized_size() {
 #[test]
 fn test_serialized_size_bounded() {
     // JUST RIGHT
-    assert!(config().limit(1).serialized_size(&0u8).unwrap() == 1);
-    assert!(config().limit(2).serialized_size(&0u16).unwrap() == 2);
-    assert!(config().limit(4).serialized_size(&0u32).unwrap() == 4);
-    assert!(config().limit(8).serialized_size(&0u64).unwrap() == 8);
-    assert!(config().limit(8).serialized_size(&"").unwrap() == 8);
-    assert!(config().limit(8 + 1).serialized_size(&"a").unwrap() == 8 + 1);
+    assert!(DefaultOptions::new().with_limit(1).serialized_size(&0u8).unwrap() == 1);
+    assert!(DefaultOptions::new().with_limit(2).serialized_size(&0u16).unwrap() == 2);
+    assert!(DefaultOptions::new().with_limit(4).serialized_size(&0u32).unwrap() == 4);
+    assert!(DefaultOptions::new().with_limit(8).serialized_size(&0u64).unwrap() == 8);
+    assert!(DefaultOptions::new().with_limit(8).serialized_size(&"").unwrap() == 8);
+    assert!(DefaultOptions::new().with_limit(8 + 1).serialized_size(&"a").unwrap() == 8 + 1);
     assert!(
-        config()
-            .limit(8 + 3 * 4)
+        DefaultOptions::new()
+            .with_limit(8 + 3 * 4)
             .serialized_size(&vec![0u32, 1u32, 2u32])
             .unwrap()
             == 8 + 3 * 4
     );
     // Below
-    assert!(config().limit(0).serialized_size(&0u8).is_err());
-    assert!(config().limit(1).serialized_size(&0u16).is_err());
-    assert!(config().limit(3).serialized_size(&0u32).is_err());
-    assert!(config().limit(7).serialized_size(&0u64).is_err());
-    assert!(config().limit(7).serialized_size(&"").is_err());
-    assert!(config().limit(8 + 0).serialized_size(&"a").is_err());
-    assert!(config()
-        .limit(8 + 3 * 4 - 1)
+    assert!(DefaultOptions::new().with_limit(0).serialized_size(&0u8).is_err());
+    assert!(DefaultOptions::new().with_limit(1).serialized_size(&0u16).is_err());
+    assert!(DefaultOptions::new().with_limit(3).serialized_size(&0u32).is_err());
+    assert!(DefaultOptions::new().with_limit(7).serialized_size(&0u64).is_err());
+    assert!(DefaultOptions::new().with_limit(7).serialized_size(&"").is_err());
+    assert!(DefaultOptions::new().with_limit(8 + 0).serialized_size(&"a").is_err());
+    assert!(DefaultOptions::new()
+        .with_limit(8 + 3 * 4 - 1)
         .serialized_size(&vec![0u32, 1u32, 2u32])
         .is_err());
 }
@@ -416,15 +416,15 @@ fn test_oom_protection() {
         len: u64,
         byte: u8,
     }
-    let x = config()
-        .limit(10)
+    let x = DefaultOptions::new()
+        .with_limit(10)
         .serialize(&FakeVec {
             len: 0xffffffffffffffffu64,
             byte: 1,
         })
         .unwrap();
-    let y: Result<Vec<u8>> = config()
-        .limit(10)
+    let y: Result<Vec<u8>> = DefaultOptions::new()
+        .with_limit(10)
         .deserialize_from(&mut Cursor::new(&x[..]));
     assert!(y.is_err());
 }
@@ -458,7 +458,7 @@ fn serde_bytes() {
 fn endian_difference() {
     let x = 10u64;
     let little = serialize(&x).unwrap();
-    let big = config().big_endian().serialize(&x).unwrap();
+    let big = DefaultOptions::new().with_big_endian().serialize(&x).unwrap();
     assert_ne!(little, big);
 }
 
@@ -647,7 +647,7 @@ where
 
 #[test]
 fn test_default_deserialize_seed() {
-    let config = config();
+    let config = DefaultOptions::new();
 
     let data: Vec<_> = (10..100).collect();
     let bytes = config.serialize(&data).expect("Config::serialize failed");
@@ -665,8 +665,7 @@ fn test_default_deserialize_seed() {
 
 #[test]
 fn test_big_endian_deserialize_seed() {
-    let mut config = config();
-    config.big_endian();
+    let config = DefaultOptions::new().with_big_endian();
 
     let data: Vec<_> = (10..100).collect();
     let bytes = config.serialize(&data).expect("Config::serialize failed");
@@ -684,7 +683,7 @@ fn test_big_endian_deserialize_seed() {
 
 #[test]
 fn test_default_deserialize_from_seed() {
-    let config = config();
+    let config = DefaultOptions::new();
 
     let data: Vec<_> = (10..100).collect();
     let bytes = config.serialize(&data).expect("Config::serialize failed");
@@ -702,8 +701,7 @@ fn test_default_deserialize_from_seed() {
 
 #[test]
 fn test_big_endian_deserialize_from_seed() {
-    let mut config = config();
-    config.big_endian();
+    let config = DefaultOptions::new().with_big_endian();
 
     let data: Vec<_> = (10..100).collect();
     let bytes = config.serialize(&data).expect("Config::serialize failed");


### PR DESCRIPTION
This is a **_very_** early PR that explores if its possible to expose the `Serializer` and `Deserializer` in a way that would allow us to expand options in the future.

## Basic Design
- expose the `DefaultOptions` and `OptionsExt` traits publicly.
- expose `Serializer` and `Deserializer` publicly.
- keep all other traits and structs `Compound, Options` private

I believe this would allow us to implement any future improvements in a backwards compatible manner. `OptionsExt` can't be implemented by 3rd party crates since it is sealed, so adding new methods should be fine.

## Remarks
- A custom ByteOrder trait was created that provides a thin wrapper over the `byteorder` trait.
  This enables us to add features to our endian behavior in the future without breaking the public API. e.g. making varint respect the endian choices.

## Unanswered Questions
- How should this be integrated with the current `config()` API?
- Who (if anyone) is using the non-public `SerializerAcceptor` trait, and does this make that obsolete?

Tagging @jdm since (I think?) you would have perspective if servo is using these non-public APIs
Tagging @dtolnay since you had significant input on the current config implementation