### PR TITLE
Fix Deserializer::{from_slice, with_reader} types

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -42,23 +42,27 @@ macro_rules! impl_deserialize_literal {
     };
 }
 
-impl<'de, R: BincodeRead<'de>, O: Options> Deserializer<R, O> {
+impl<'de, IR: Read, O: Options> Deserializer<IoReader<IR>, O> {
     /// Creates a new Deserializer with a given `Read`er and options.
-    pub fn with_reader<IR: Read>(r: IR, options: O) -> Deserializer<IoReader<IR>, O> {
+    pub fn with_reader(r: IR, options: O) -> Self {
         Deserializer {
             reader: IoReader::new(r),
             options,
         }
     }
+}
 
+impl<'de, O: Options> Deserializer<SliceReader<'de>, O> {
     /// Creates a new Deserializer that will read from the given slice.
-    pub fn from_slice(slice: &'de [u8], options: O) -> Deserializer<SliceReader<'de>, O> {
+    pub fn from_slice(slice: &'de [u8], options: O) -> Self {
         Deserializer {
             reader: SliceReader::new(slice),
             options,
         }
     }
+}
 
+impl<'de, R: BincodeRead<'de>, O: Options> Deserializer<R, O> {
     /// Creates a new Deserializer with the given `BincodeRead`er
     pub fn with_bincode_read(r: R, options: O) -> Deserializer<R, O> {
         Deserializer { reader: r, options }


### PR DESCRIPTION
Having these in the `impl` block with a generic `R` paramter would make them unusable, at least without type annotations:

    error[E0282]: type annotations needed
      --> msg_socket2/src/socket.rs:45:32
       |
    45 |         let mut deserializer = Deserializer::with_reader(bytes.as_slice(), DefaultOptions::new());
       |                                ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `R`

    error: aborting due to previous error

    For more information about this error, try `rustc --explain E0282`.

Moving these into separate `impl` blocks, which set the type of the `Deserializer` to the return type of the functions, fixes this error.