### PR TITLE
[WIP] no_std support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,52 @@
         }
       ]
     },
+    "check_features": {
+      "name": "Check features",
+      "runs-on": "ubuntu-latest",
+      "strategy": {
+        "fail-fast": false,
+        "matrix": {
+          "feature": [
+            "std",
+            "alloc",
+            "i128"
+          ]
+        }
+      },
+      "steps": [
+        {
+          "uses": "actions/checkout@v2",
+          "name": "Checkout"
+        },
+        {
+          "uses": "actions-rs/toolchain@v1",
+          "with": {
+            "profile": "minimal",
+            "toolchain": "stable",
+            "override": true
+          },
+          "name": "Install Rust stable"
+        },
+        {
+          "uses": "actions-rs/cargo@v1",
+          "with": {
+            "command": "check",
+            "args": "--default-features false --features ${{ matrix.feature }}"
+          },
+          "name": "Run `cargo check`"
+        },
+        {
+          "uses": "actions-rs/cargo@v1",
+          "with": {
+            "command": "check",
+            "args": "--examples"
+          },
+          "name": "Check examples",
+          "if": "matrix.rust != '1.18.0'"
+        }
+      ]
+    },
     "test": {
       "name": "Test",
       "runs-on": "ubuntu-latest",

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,7 +90,7 @@
           "uses": "actions-rs/cargo@v1",
           "with": {
             "command": "check",
-            "args": "--default-features false --features ${{ matrix.feature }}"
+            "args": "--no-default-features --features ${{ matrix.feature }}"
           },
           "name": "Run `cargo check`"
         },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ license = "MIT"
 description = "A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!"
 
 [dependencies]
-byteorder = "1.3.0"
-serde = "1.0.63"
+byteorder = { version = "1.3.0", default-features = false }
+serde = { version = "1.0.63", default-features = false }
 
 [dev-dependencies]
 serde_bytes = "0.11"
@@ -29,6 +29,9 @@ serde_derive = "1.0.27"
 # and targets that support it. The feature will be removed if and when a new
 # major version is released.
 i128 = []
+default = ["std"]
+std = ["byteorder/std", "serde/std"]
+alloc = ["serde/alloc"]
 
 [badges]
 travis-ci = { repository = "servo/bincode" }

--- a/src/config/int.rs
+++ b/src/config/int.rs
@@ -1,5 +1,6 @@
-use std::io::Write;
-use std::mem::size_of;
+use crate::imports::box_new;
+use crate::imports::io::Write;
+use crate::imports::mem::size_of;
 
 use super::Options;
 use de::read::BincodeRead;
@@ -247,12 +248,12 @@ impl VarintEncoding {
             U16_BYTE => Ok(de.deserialize_literal_u16()? as u64),
             U32_BYTE => Ok(de.deserialize_literal_u32()? as u64),
             U64_BYTE => de.deserialize_literal_u64(),
-            U128_BYTE => Err(Box::new(ErrorKind::Custom(
+            U128_BYTE => Err(box_new(ErrorKind::Custom(
                 "Invalid value (u128 range): you may have a version or configuration disagreement?"
-                    .to_string(),
+                    .into(),
             ))),
-            _ => Err(Box::new(ErrorKind::Custom(
-                DESERIALIZE_EXTENSION_POINT_ERR.to_string(),
+            _ => Err(box_new(ErrorKind::Custom(
+                DESERIALIZE_EXTENSION_POINT_ERR.into(),
             ))),
         }
     }
@@ -321,7 +322,7 @@ impl VarintEncoding {
                 U32_BYTE => Ok(de.deserialize_literal_u32()? as u128),
                 U64_BYTE => Ok(de.deserialize_literal_u64()? as u128),
                 U128_BYTE => de.deserialize_literal_u128(),
-                _ => Err(Box::new(ErrorKind::Custom(DESERIALIZE_EXTENSION_POINT_ERR.to_string()))),
+                _ => Err(box_new(ErrorKind::Custom(DESERIALIZE_EXTENSION_POINT_ERR.into()))),
             }
         }
     }
@@ -594,31 +595,30 @@ fn cast_u64_to_usize(n: u64) -> Result<usize> {
     if n <= usize::max_value() as u64 {
         Ok(n as usize)
     } else {
-        Err(Box::new(ErrorKind::Custom(format!(
-            "Invalid size {}: sizes must fit in a usize (0 to {})",
-            n,
-            usize::max_value()
-        ))))
+        Err(box_new(ErrorKind::InvalidCast {
+            from_type: "u64",
+            to_type: "usize",
+        }))
     }
 }
 fn cast_u64_to_u32(n: u64) -> Result<u32> {
     if n <= u32::max_value() as u64 {
         Ok(n as u32)
     } else {
-        Err(Box::new(ErrorKind::Custom(format!(
-            "Invalid u32 {}: you may have a version disagreement?",
-            n,
-        ))))
+        Err(box_new(ErrorKind::InvalidCast {
+            from_type: "u64",
+            to_type: "u32",
+        }))
     }
 }
 fn cast_u64_to_u16(n: u64) -> Result<u16> {
     if n <= u16::max_value() as u64 {
         Ok(n as u16)
     } else {
-        Err(Box::new(ErrorKind::Custom(format!(
-            "Invalid u16 {}: you may have a version disagreement?",
-            n,
-        ))))
+        Err(box_new(ErrorKind::InvalidCast {
+            from_type: "u64",
+            to_type: "u16",
+        }))
     }
 }
 
@@ -626,10 +626,10 @@ fn cast_i64_to_i32(n: i64) -> Result<i32> {
     if n <= i32::max_value() as i64 && n >= i32::min_value() as i64 {
         Ok(n as i32)
     } else {
-        Err(Box::new(ErrorKind::Custom(format!(
-            "Invalid i32 {}: you may have a version disagreement?",
-            n,
-        ))))
+        Err(box_new(ErrorKind::InvalidCast {
+            from_type: "i16",
+            to_type: "i32",
+        }))
     }
 }
 
@@ -637,10 +637,10 @@ fn cast_i64_to_i16(n: i64) -> Result<i16> {
     if n <= i16::max_value() as i64 && n >= i16::min_value() as i64 {
         Ok(n as i16)
     } else {
-        Err(Box::new(ErrorKind::Custom(format!(
-            "Invalid i16 {}: you may have a version disagreement?",
-            n,
-        ))))
+        Err(box_new(ErrorKind::InvalidCast {
+            from_type: "i64",
+            to_type: "i16",
+        }))
     }
 }
 

--- a/src/config/legacy.rs
+++ b/src/config/legacy.rs
@@ -1,11 +1,15 @@
-use std::io::{Read, Write};
-
 use self::EndianOption::*;
 use self::LimitOption::*;
 use super::{DefaultOptions, Options};
+use crate::imports::io::Write;
 use de::read::BincodeRead;
 use error::Result;
 use serde;
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+use crate::imports::io::Read;
+#[cfg(any(feature = "std", feature = "alloc"))]
+use crate::imports::Vec;
 
 /// A configuration builder whose options Bincode will use
 /// while serializing and deserializing.
@@ -147,6 +151,7 @@ impl Config {
 
     /// Serializes a serializable object into a `Vec` of bytes using this configuration
     #[inline(always)]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     pub fn serialize<T: ?Sized + serde::Serialize>(&self, t: &T) -> Result<Vec<u8>> {
         config_map!(self, opts => ::internal::serialize(t, opts))
     }
@@ -201,6 +206,7 @@ impl Config {
     ///
     /// If this returns an `Error`, `reader` may be in an invalid state.
     #[inline(always)]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     pub fn deserialize_from<R: Read, T: serde::de::DeserializeOwned>(
         &self,
         reader: R,
@@ -212,6 +218,7 @@ impl Config {
     ///
     /// If this returns an `Error`, `reader` may be in an invalid state.
     #[inline(always)]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     pub fn deserialize_from_seed<'a, R: Read, T: serde::de::DeserializeSeed<'a>>(
         &self,
         seed: T,

--- a/src/config/limit.rs
+++ b/src/config/limit.rs
@@ -1,3 +1,4 @@
+use crate::imports::box_new;
 use error::{ErrorKind, Result};
 
 /// A trait for stopping serialization and deserialization when a certain limit has been reached.
@@ -26,7 +27,7 @@ impl SizeLimit for Bounded {
             self.0 -= n;
             Ok(())
         } else {
-            Err(Box::new(ErrorKind::SizeLimit))
+            Err(box_new(ErrorKind::SizeLimit))
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,8 +1,13 @@
+use crate::imports::io::Write;
+use crate::imports::marker::PhantomData;
 use de::read::BincodeRead;
 use error::Result;
 use serde;
-use std::io::{Read, Write};
-use std::marker::PhantomData;
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+use crate::imports::io::Read;
+#[cfg(any(feature = "std", feature = "alloc"))]
+use crate::imports::Vec;
 
 pub(crate) use self::endian::BincodeByteOrder;
 pub(crate) use self::int::IntEncoding;
@@ -131,6 +136,7 @@ pub trait Options: InternalOptions + Sized {
 
     /// Serializes a serializable object into a `Vec` of bytes using this configuration
     #[inline(always)]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     fn serialize<S: ?Sized + serde::Serialize>(self, t: &S) -> Result<Vec<u8>> {
         ::internal::serialize(t, self)
     }
@@ -181,6 +187,7 @@ pub trait Options: InternalOptions + Sized {
     ///
     /// If this returns an `Error`, `reader` may be in an invalid state.
     #[inline(always)]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     fn deserialize_from<R: Read, T: serde::de::DeserializeOwned>(self, reader: R) -> Result<T> {
         ::internal::deserialize_from(reader, self)
     }
@@ -189,6 +196,7 @@ pub trait Options: InternalOptions + Sized {
     ///
     /// If this returns an `Error`, `reader` may be in an invalid state.
     #[inline(always)]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     fn deserialize_from_seed<'a, R: Read, T: serde::de::DeserializeSeed<'a>>(
         self,
         seed: T,

--- a/src/config/trailing.rs
+++ b/src/config/trailing.rs
@@ -1,3 +1,4 @@
+use crate::imports::box_new;
 use de::read::SliceReader;
 use {ErrorKind, Result};
 
@@ -29,8 +30,8 @@ impl TrailingBytes for RejectTrailing {
         if reader.is_finished() {
             Ok(())
         } else {
-            Err(Box::new(ErrorKind::Custom(
-                "Slice had bytes remaining after deserialization".to_string(),
+            Err(box_new(ErrorKind::Custom(
+                "Slice had bytes remaining after deserialization".into(),
             )))
         }
     }

--- a/src/imports/io.rs
+++ b/src/imports/io.rs
@@ -1,0 +1,102 @@
+// Bincode's write trait. In std this is automatically implemented for all types that implement std::io::Write
+pub trait Write {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Error>;
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Error> {
+        let len = self.write(buf)?;
+
+        if len != buf.len() {
+            Err(ErrorKind::UnexpectedEof.into())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+// Bincode's read trait. In std this is automatically implemented for all types that implement std::io::Read
+pub trait Read {
+    fn read(&mut self, out: &mut [u8]) -> Result<usize, Error>;
+    fn read_exact(&mut self, out: &mut [u8]) -> Result<(), Error>;
+}
+
+#[cfg(not(feature = "std"))]
+impl<'a> Read for &'a [u8] {
+    fn read(&mut self, out: &mut [u8]) -> Result<usize, Error> {
+        if out.len() < self.len() {
+            out.copy_from_slice(&self[..out.len()]);
+            *self = &self[out.len()..];
+            Ok(out.len())
+        } else {
+            let len = self.len();
+            out[..len].copy_from_slice(self);
+            *self = &[];
+            Ok(len)
+        }
+    }
+    fn read_exact(&mut self, out: &mut [u8]) -> Result<(), Error> {
+        if out.len() < self.len() {
+            out.copy_from_slice(&self[..out.len()]);
+            *self = &self[out.len()..];
+            Ok(())
+        } else {
+            Err(ErrorKind::UnexpectedEof.into())
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+pub use std::io::{Error, ErrorKind};
+
+#[cfg(not(feature = "std"))]
+pub use self::error::*;
+#[cfg(not(feature = "std"))]
+mod error {
+    #[derive(Debug)]
+    pub struct Error {
+        kind: ErrorKind,
+        message: Option<&'static str>,
+    }
+
+    impl Error {
+        pub fn description(&self) -> &str {
+            if let Some(message) = &self.message {
+                message
+            } else {
+                self.kind.description()
+            }
+        }
+    }
+
+    impl core::fmt::Display for Error {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            write!(fmt, "{}", self.description())
+        }
+    }
+
+    impl Error {
+        pub fn kind(&self) -> ErrorKind {
+            self.kind
+        }
+    }
+
+    impl From<ErrorKind> for Error {
+        fn from(kind: ErrorKind) -> Error {
+            Error {
+                kind,
+                message: None,
+            }
+        }
+    }
+
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum ErrorKind {
+        UnexpectedEof,
+    }
+
+    impl ErrorKind {
+        pub fn description(&self) -> &str {
+            match self {
+                ErrorKind::UnexpectedEof => "Unexpected EOF",
+            }
+        }
+    }
+}

--- a/src/imports/mod.rs
+++ b/src/imports/mod.rs
@@ -1,0 +1,96 @@
+// This file has the purpose of shimming out std structs if we're running in no_std or alloc mode
+// The following types should be exported:
+// - Box<T>
+// - StdError (renamed from std::error::Error)
+// - String/ToString (if available)
+// - Vec<T> (if available)
+// - Either std::mem or core::mem
+// - Either std::marker or core::marker
+// - Either std::str or core::str
+// - Either std::u32 or core::u32
+// - Either std::fmt or core::fmt
+// - Either std::result or core::result
+// - vec![] macro (if available)
+
+pub mod io;
+
+#[cfg(feature = "std")]
+mod inner {
+    // std support, just re-export everything
+    pub use std::boxed::Box;
+    pub use std::error::Error as StdError;
+    pub use std::string::{String, ToString};
+    pub use std::vec;
+    pub use std::vec::Vec;
+    pub use std::{fmt, marker, mem, result, str, u32};
+
+    impl<R: std::io::Read> super::io::Read for R {
+        fn read(&mut self, out: &mut [u8]) -> Result<usize, super::io::Error> {
+            std::io::Read::read(self, out)
+        }
+        fn read_exact(&mut self, out: &mut [u8]) -> Result<(), super::io::Error> {
+            std::io::Read::read_exact(self, out)
+        }
+    }
+    impl<W: std::io::Write> super::io::Write for W {
+        fn write(&mut self, buf: &[u8]) -> Result<usize, super::io::Error> {
+            std::io::Write::write(self, buf)
+        }
+    }
+
+    pub fn box_new<T>(t: T) -> Box<T> {
+        Box::new(t)
+    }
+}
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+mod inner {
+    // alloc support, use the alloc crate
+    extern crate alloc;
+    pub use alloc::boxed::Box;
+    pub use alloc::string::{String, ToString};
+    pub use alloc::vec;
+    pub use alloc::vec::Vec;
+    pub use core::{fmt, marker, mem, result, str, u32};
+
+    pub trait StdError {}
+
+    pub fn box_new<T>(t: T) -> Box<T> {
+        Box::new(t)
+    }
+
+    impl<'a> super::io::Write for &'a mut Vec<u8> {
+        fn write(&mut self, buf: &[u8]) -> Result<usize, super::io::Error> {
+            self.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+    }
+    impl super::io::Write for Vec<u8> {
+        fn write(&mut self, buf: &[u8]) -> Result<usize, super::io::Error> {
+            self.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+    }
+}
+
+#[cfg(not(any(feature = "alloc", feature = "std")))]
+mod inner {
+    // No alloc and no std, use only the bare minimum
+
+    pub use core::{fmt, marker, mem, result, str, u32};
+
+    // Box is just a newtype for T
+    pub type Box<T> = T;
+
+    pub fn box_new<T>(t: T) -> Box<T> {
+        t
+    }
+
+    // TODO: Vec<T>
+    // pub type Vec<T> = &'static [T];
+
+    // TODO: Read/Write traits
+    pub trait StdError {}
+}
+
+pub use self::inner::*;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,10 +1,12 @@
-use serde;
-use std::io::{Read, Write};
-use std::marker::PhantomData;
-
+use crate::imports::io::{Read, Write};
+use crate::imports::marker::PhantomData;
 use config::{Infinite, InternalOptions, Options, SizeLimit, TrailingBytes};
 use de::read::BincodeRead;
+use serde;
 use Result;
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+use crate::imports::Vec;
 
 pub(crate) fn serialize_into<W, T: ?Sized, O>(writer: W, value: &T, mut options: O) -> Result<()>
 where
@@ -22,6 +24,7 @@ where
     serde::Serialize::serialize(value, &mut serializer)
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub(crate) fn serialize<T: ?Sized, O>(value: &T, mut options: O) -> Result<Vec<u8>>
 where
     T: serde::Serialize,
@@ -46,6 +49,7 @@ where
     result.map(|_| size_counter.total)
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub(crate) fn deserialize_from<R, T, O>(reader: R, options: O) -> Result<T>
 where
     R: Read,
@@ -55,6 +59,7 @@ where
     deserialize_from_seed(PhantomData, reader, options)
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub(crate) fn deserialize_from_seed<'a, R, T, O>(seed: T, reader: R, options: O) -> Result<T::Value>
 where
     R: Read,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,10 @@
 #![crate_name = "bincode"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+extern crate alloc;
 
 extern crate byteorder;
 #[macro_use]
@@ -39,6 +43,7 @@ pub mod config;
 pub mod de;
 
 mod error;
+mod imports;
 mod internal;
 mod ser;
 
@@ -79,7 +84,7 @@ pub fn options() -> DefaultOptions {
 /// is returned and *no bytes* will be written into the `Writer`.
 pub fn serialize_into<W, T: ?Sized>(writer: W, value: &T) -> Result<()>
 where
-    W: std::io::Write,
+    W: ::imports::io::Write,
     T: serde::Serialize,
 {
     DefaultOptions::new()
@@ -87,8 +92,11 @@ where
         .serialize_into(writer, value)
 }
 
+#[cfg(any(feature = "std", feature = "alloc"))]
 /// Serializes a serializable object into a `Vec` of bytes using the default configuration.
-pub fn serialize<T: ?Sized>(value: &T) -> Result<Vec<u8>>
+///
+/// This function is not available without either the `std` or `alloc` feature, which are enabled by default.
+pub fn serialize<T: ?Sized>(value: &T) -> Result<::imports::Vec<u8>>
 where
     T: serde::Serialize,
 {
@@ -101,9 +109,10 @@ where
 /// Deserializes an object directly from a `Read`er using the default configuration.
 ///
 /// If this returns an `Error`, `reader` may be in an invalid state.
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub fn deserialize_from<R, T>(reader: R) -> Result<T>
 where
-    R: std::io::Read,
+    R: ::imports::io::Read,
     T: serde::de::DeserializeOwned,
 {
     DefaultOptions::new()

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,14 +1,12 @@
-use std::io::Write;
-use std::u32;
+use crate::imports::io::Write;
+use crate::imports::u32;
 
 use serde;
 
-use byteorder::WriteBytesExt;
-
 use super::config::{IntEncoding, SizeLimit};
 use super::{Error, ErrorKind, Result};
+use crate::imports::mem::size_of;
 use config::{BincodeByteOrder, Options};
-use std::mem::size_of;
 
 /// An Serializer that encodes values directly into a Writer.
 ///


### PR DESCRIPTION
Started working on `no_std` support

:warning: This is a breaking change :warning: 

This PR adds 3 new features:
- `std` (enabled by default)
- `alloc` has no std support, but does support strings, collections and boxes
- no features, `no_std`. This disables all allocations and OS-specific code.

The changes in this PR are: (unchecked features are not final)
- [ ] `std::io::Read/Write` doesn't exist in `core` ([tracking issue](https://github.com/rust-lang/rfcs/issues/2262)) This is solved by implementing our own `Read/Write` traits
- [ ] `std::io::Error` and `std::error::Error` are also not available. We create our own io error type, and we explicitly implement `serde::de::Error` when we're in no_std mode
- [ ] `byteorder::ReadBytesExt` and `byteorder::WriteBytesExt` are not available outside of `std` mode. ([Related issue](https://github.com/BurntSushi/byteorder/issues/137) that states that they're waiting on RFC 2262)


